### PR TITLE
[codex] add remote mcp feedback entrypoint

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/local-mcp-server-issue.md
+++ b/.github/ISSUE_TEMPLATE/local-mcp-server-issue.md
@@ -1,0 +1,68 @@
+---
+name: Local MCP server issue
+about: Report an issue with the local/self-hosted MaxCompute MCP server in this repository
+title: "[LOCAL] "
+labels: local, needs-triage
+assignees: ""
+---
+
+This template is for the local or self-hosted MaxCompute MCP server code in
+this repository. For hosted MaxCompute Remote MCP service feedback, use the
+Remote MCP service feedback template instead.
+
+Do not include AccessKey IDs, AccessKey secrets, STS tokens, bearer tokens,
+customer data, sensitive SQL, or sensitive Logview content.
+
+## Issue type
+
+- [ ] Bug in local MCP server
+- [ ] Local setup or configuration issue
+- [ ] Local server tool or feature request
+- [ ] Documentation feedback for local setup
+
+## Environment
+
+- OS:
+- Python version:
+- `uv` version:
+- Repository commit:
+- Transport: stdio / Streamable HTTP
+- MCP client name and version:
+
+## Configuration shape
+
+Describe the local configuration shape without secrets.
+
+- Uses `config.json`: yes / no
+- Uses environment variables only: yes / no
+- Uses `ALIBABA_CLOUD_CREDENTIALS_URI`: yes / no
+- MaxCompute endpoint region:
+
+## Tool or workflow
+
+- MCP tool name, if related to an existing tool:
+- Sanitized error code/message:
+
+## Description
+
+Describe what happened.
+
+## Expected behavior
+
+Describe what you expected to happen.
+
+## Actual behavior
+
+Describe the actual behavior. Include only sanitized output.
+
+## Reproduction steps
+
+1.
+2.
+3.
+
+## Redaction checklist
+
+- [ ] I removed AccessKey IDs, AccessKey secrets, STS tokens, and bearer tokens.
+- [ ] I removed customer data, sensitive SQL, and sensitive Logview content.
+- [ ] I did not include local credential files or private configuration.

--- a/.github/ISSUE_TEMPLATE/remote-mcp-service-feedback.md
+++ b/.github/ISSUE_TEMPLATE/remote-mcp-service-feedback.md
@@ -1,0 +1,63 @@
+---
+name: Remote MCP service feedback
+about: Report public, non-sensitive feedback for the hosted MaxCompute Remote MCP service
+title: "[REMOTE] "
+labels: remote, needs-triage
+assignees: ""
+---
+
+This template is for public, non-sensitive feedback about the hosted
+MaxCompute Remote MCP service.
+
+Do not include access tokens, refresh tokens, authorization codes, cookies,
+AccessKey IDs or secrets, OAuth callback URLs with query strings, sensitive SQL,
+customer data, or sensitive Logview content.
+
+Use official Alibaba Cloud support or security channels instead of public
+GitHub issues for account-specific permissions, billing, SLA-bound incidents,
+production outages, vulnerabilities, or confidential data cases.
+
+## Issue type
+
+- [ ] Feedback on Remote MCP Server
+- [ ] Bug in Remote MCP Server
+- [ ] Tool or feature request for Remote MCP Server
+- [ ] Documentation feedback
+
+## Client and endpoint
+
+- MCP client name and version:
+- Endpoint type: public / VPC / unknown
+- Remote MCP endpoint or service region:
+- Approximate time window with timezone:
+
+## Tool or workflow
+
+- MCP tool name, if related to an existing tool:
+- Request ID, if available:
+- Region or project context, if safe to share:
+
+## Description
+
+Describe what happened.
+
+## Expected behavior
+
+Describe what you expected to happen.
+
+## Actual behavior
+
+Describe the actual behavior. Include only sanitized error codes or messages.
+
+## Reproduction steps
+
+1.
+2.
+3.
+
+## Redaction checklist
+
+- [ ] I removed tokens, cookies, authorization codes, and callback URL query parameters.
+- [ ] I removed AccessKey IDs, AccessKey secrets, STS tokens, and bearer tokens.
+- [ ] I removed sensitive SQL, customer data, and sensitive Logview content.
+- [ ] This issue does not require account-specific, billing, SLA, outage, or security handling.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@
 
 A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for Alibaba Cloud [MaxCompute](https://www.alibabacloud.com/product/maxcompute). It exposes Catalog API and compute capabilities as MCP tools so that AI assistants such as Cursor and Claude Code can list projects / schemas / tables, search metadata, estimate and execute SQL, and manage MaxCompute instances over stdio or Streamable HTTP.
 
+> [!IMPORTANT]
+> MaxCompute Remote MCP Server is the recommended way to use MaxCompute MCP.
+> Start with the hosted Remote MCP service documentation:
+> [MaxCompute MCP service (Remote MCP Server)](https://www.alibabacloud.com/help/en/maxcompute/getting-started/mcmcp-service-remote-mcp-server).
+>
+> This repository continues to host the local MCP server code for self-hosted
+> and development scenarios. During the Remote MCP rollout, public,
+> non-sensitive Remote MCP feedback is tracked through this repository's
+> [Remote MCP issue template](https://github.com/aliyun/alibabacloud-maxcompute-mcp-server/issues/new?template=remote-mcp-service-feedback.md).
+
 ## Features
 
 - **Catalog**: list projects / schemas / tables; get project, schema, table and partition details.
@@ -17,13 +27,51 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for Al
 - **Identity & access**: `check_access` combines identity discovery and grant inspection.
 - **Transports**: stdio (default, for IDE integration) and Streamable HTTP (built-in, no `mcp-proxy` needed).
 
-## Requirements
+## Remote MCP Server (Recommended)
+
+Use the hosted MaxCompute Remote MCP Server first unless you specifically need
+a local `stdio` or self-hosted setup. The remote service removes local runtime
+and credential setup from the MCP server process, uses Streamable HTTP, and
+follows the official Alibaba Cloud onboarding flow.
+
+For setup instructions, supported endpoints, OAuth login flow, tool
+capabilities, and safety notes, see:
+
+- [MaxCompute MCP service (Remote MCP Server)](https://www.alibabacloud.com/help/en/maxcompute/getting-started/mcmcp-service-remote-mcp-server)
+
+### Remote MCP feedback
+
+Use this repository's issues for public, non-sensitive Remote MCP feedback:
+
+- [Report Remote MCP feedback](https://github.com/aliyun/alibabacloud-maxcompute-mcp-server/issues/new?template=remote-mcp-service-feedback.md)
+- [View existing issues](https://github.com/aliyun/alibabacloud-maxcompute-mcp-server/issues)
+
+Include the MCP client name/version, endpoint type, tool name, request ID,
+time window with timezone, region, sanitized error code/message, expected
+behavior, actual behavior, and reproduction steps when available.
+
+Do not include access tokens, refresh tokens, authorization codes, cookies,
+AccessKey IDs or secrets, OAuth callback URLs with query strings, sensitive SQL,
+customer data, or sensitive Logview content. Use official Alibaba Cloud support
+or security channels for account-specific permissions, billing, SLA-bound
+incidents, production outages, vulnerabilities, or confidential data cases.
+
+## Local MCP Server (Optional)
+
+The sections below describe the local MCP server in this repository. Use the
+local server when you need self-hosting, stdio integration, local development,
+or direct credential control. For the hosted service, follow the Remote MCP
+documentation above instead.
+
+### Requirements
+
+The local MCP server needs:
 
 - Python 3.10 or newer.
 - [`uv`](https://docs.astral.sh/uv/) for dependency management (recommended).
 - MaxCompute access with an Access Key / STS credentials / credentials URI.
 
-## Installation (source checkout)
+### Installation
 
 This first public release is distributed as a source repository only. PyPI and standalone tarballs are not available in this phase.
 
@@ -39,7 +87,7 @@ Verify the entry point:
 uv run alibabacloud-maxcompute-mcp-server --help
 ```
 
-## Configuration
+### Configuration
 
 Copy the public example and fill in real values locally:
 
@@ -50,7 +98,7 @@ cp config.example.json config.json
 
 `config.json` is git-ignored by default and must not be committed.
 
-### Configuration fields
+#### Configuration fields
 
 | Field | Required | Description |
 | --- | --- | --- |
@@ -61,14 +109,14 @@ cp config.example.json config.json
 | `maxcompute.protocol` | optional | `https` (default) or `http`. |
 | `maxcompute.accessKeyId` / `accessKeySecret` | optional | Static credentials for development. Prefer `ALIBABA_CLOUD_CREDENTIALS_URI` in production. |
 
-### Credential precedence
+#### Credential precedence
 
 1. `ALIBABA_CLOUD_ACCESS_KEY_ID` / `ALIBABA_CLOUD_ACCESS_KEY_SECRET` environment variables (optionally with `ALIBABA_CLOUD_SECURITY_TOKEN`).
 2. `ALIBABA_CLOUD_CREDENTIALS_URI` pointing to a local credential provider.
 3. The Alibaba Cloud default credential chain (environment, file, ECS RAM role, etc.).
 4. Static `accessKeyId` / `accessKeySecret` inside `config.json` (lowest priority, development only).
 
-### Environment-variable-only mode
+#### Environment-variable-only mode
 
 You can skip the JSON file entirely and configure the server through environment variables:
 
@@ -82,7 +130,7 @@ You can skip the JSON file entirely and configure the server through environment
 | `ALIBABA_CLOUD_SECURITY_TOKEN` | Optional STS token. |
 | `ALIBABA_CLOUD_CREDENTIALS_URI` | Credential provider URI. |
 
-### Named configs (runtime switching)
+#### Named configs (runtime switching)
 
 To switch between regions, endpoints, projects, or identities without restarting the MCP server, create a local multi-config file such as `config.multi.json` and point `MAXCOMPUTE_CATALOG_CONFIG` to it:
 
@@ -131,21 +179,21 @@ Each named config must provide `maxcompute_endpoint`. If `catalogapi_endpoint` i
 
 The active config is process-global. Runtime switching is best suited to stdio / single-client usage. In shared Streamable HTTP mode, all connected clients share the same active config, so a `use_config` call from one client affects the others.
 
-## Running
+### Running
 
-### stdio (default)
+#### stdio (default)
 
 ```bash
 uv run alibabacloud-maxcompute-mcp-server
 ```
 
-### Streamable HTTP
+#### Streamable HTTP
 
 ```bash
 uv run alibabacloud-maxcompute-mcp-server --transport http --host 127.0.0.1 --port 8000
 ```
 
-## MCP tools
+### MCP tools
 
 All tools return JSON in an MCP text response. Check `success` first, then read `data`, `summary`, or `error`.
 
@@ -164,9 +212,9 @@ Notes:
 - `search_meta_data` requires `namespaceId` / `MAXCOMPUTE_NAMESPACE_ID`.
 - Large query results can be streamed to a local `file://` `output_uri`; otherwise responses are returned inline and may be truncated.
 
-## MCP client setup
+### MCP client setup
 
-### Cursor / Claude Code (stdio, config file)
+#### Cursor / Claude Code (stdio, config file)
 
 ```json
 {
@@ -187,7 +235,7 @@ Notes:
 }
 ```
 
-### Cursor / Claude Code (stdio, environment variables only)
+#### Cursor / Claude Code (stdio, environment variables only)
 
 ```json
 {
@@ -212,11 +260,11 @@ Notes:
 }
 ```
 
-### Streamable HTTP
+#### Streamable HTTP
 
 Start the server (see above), then point your MCP client at `http://127.0.0.1:8000/mcp`.
 
-## Development
+### Development
 
 ```bash
 uv sync --all-extras
@@ -224,7 +272,7 @@ uv run pytest tests/ -q
 uv build
 ```
 
-### Package naming
+#### Package naming
 
 | Name | Context |
 | --- | --- |
@@ -236,7 +284,9 @@ The import module name predates the public package name and is kept for backward
 ## Contributing
 
 - This is the first public source release. PyPI packages and GitHub Release artifacts are **not** available in this phase.
-- Pull requests and issues are welcome. Please open an issue before starting large changes.
+- Pull requests and issues are welcome. For Remote MCP service feedback, use
+  the Remote MCP issue template. For local server code changes, please open an
+  issue before starting large changes.
 
 ## License
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -7,6 +7,15 @@
 
 基于 [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) 的阿里云 [MaxCompute](https://www.aliyun.com/product/odps) 服务端。将 Catalog API 与计算能力封装为 MCP 工具，供 Cursor、Claude Code 等 AI 助手通过 stdio 或 Streamable HTTP 列出项目/schema/表、搜索元数据、预估与执行 SQL、管理 MaxCompute 实例。
 
+> [!IMPORTANT]
+> 推荐优先使用 MaxCompute Remote MCP Server。请先阅读托管版 Remote MCP
+> 服务文档：[MaxCompute MCP 服务（Remote MCP Server）](https://www.alibabacloud.com/help/zh/maxcompute/getting-started/mcmcp-service-remote-mcp-server)。
+>
+> 本仓库继续保留 local MCP server 代码，适用于自托管、开发调试和特殊本地
+> stdio 场景。Remote MCP 推进期间，公开且不含敏感信息的反馈可以通过本仓库的
+> [Remote MCP issue 模板](https://github.com/aliyun/alibabacloud-maxcompute-mcp-server/issues/new?template=remote-mcp-service-feedback.md)
+> 提交。
+
 ## 能力概览
 
 - **Catalog**：列出项目 / schema / 表；获取项目、schema、表及分区详情
@@ -17,13 +26,45 @@
 - **身份与权限**：`check_access` 合并身份发现与权限查询
 - **传输层**：stdio（默认，适合 IDE 集成）与内置 Streamable HTTP（无需 mcp-proxy）
 
-## 运行要求
+## Remote MCP Server（推荐）
+
+除非你明确需要 local `stdio` 或自托管方式，否则建议优先使用托管版
+MaxCompute Remote MCP Server。Remote MCP 服务减少本地运行环境和 MCP
+服务端凭证配置成本，使用 Streamable HTTP，并按阿里云官方接入流程完成授权。
+
+接入步骤、支持地域、OAuth 登录流程、工具能力和安全注意事项见：
+
+- [MaxCompute MCP 服务（Remote MCP Server）](https://www.alibabacloud.com/help/zh/maxcompute/getting-started/mcmcp-service-remote-mcp-server)
+
+### Remote MCP 反馈
+
+公开且不含敏感信息的 Remote MCP 反馈可以通过本仓库 issues 提交：
+
+- [提交 Remote MCP 反馈](https://github.com/aliyun/alibabacloud-maxcompute-mcp-server/issues/new?template=remote-mcp-service-feedback.md)
+- [查看已有 issues](https://github.com/aliyun/alibabacloud-maxcompute-mcp-server/issues)
+
+建议包含 MCP Client 名称和版本、Endpoint 类型、工具名、request ID、带时区的时间窗口、
+地域、脱敏后的错误码和错误信息、期望行为、实际行为以及复现步骤。
+
+不要在公开 issue 中包含 access token、refresh token、授权码、Cookie、AccessKey ID
+或 Secret、带 query 参数的 OAuth callback URL、敏感 SQL、客户数据或敏感 Logview
+内容。账号级权限、账单、SLA、生产故障、安全漏洞或包含机密数据的问题，请使用阿里云
+官方支持或安全渠道。
+
+## Local MCP Server（可选）
+
+以下内容说明本仓库中的 local MCP server。仅在需要自托管、stdio 集成、本地开发
+或直接控制凭证时使用 local server；托管版服务请优先参考上文 Remote MCP 文档。
+
+### 运行要求
+
+Local MCP server 需要：
 
 - Python 3.10+
 - [`uv`](https://docs.astral.sh/uv/)（推荐的依赖管理工具）
 - 可访问的 MaxCompute 项目以及 AK / STS 凭证 / 凭证服务 URI
 
-## 源码安装
+### 安装
 
 首个开源版本仅以源码仓形式发布。本阶段不提供 PyPI 与 standalone 独立发行版。
 
@@ -39,7 +80,7 @@ uv sync
 uv run alibabacloud-maxcompute-mcp-server --help
 ```
 
-## 配置
+### 配置
 
 复制公共示例到本地，并填入实际值：
 
@@ -50,7 +91,7 @@ cp config.example.json config.json
 
 `config.json` 默认被 `.gitignore` 忽略，切勿提交。
 
-### 配置字段
+#### 配置字段
 
 | 字段 | 是否必填 | 说明 |
 | --- | --- | --- |
@@ -61,14 +102,14 @@ cp config.example.json config.json
 | `maxcompute.protocol` | 可选 | `https`（默认）或 `http` |
 | `maxcompute.accessKeyId` / `accessKeySecret` | 可选 | 静态凭证，仅供开发调试；生产环境建议使用凭证服务 URI |
 
-### 凭证优先级
+#### 凭证优先级
 
 1. 环境变量 `ALIBABA_CLOUD_ACCESS_KEY_ID` / `ALIBABA_CLOUD_ACCESS_KEY_SECRET`（可选携带 `ALIBABA_CLOUD_SECURITY_TOKEN`）
 2. `ALIBABA_CLOUD_CREDENTIALS_URI` 指向的本地凭证服务
 3. 阿里云默认凭证链（环境变量 / 配置文件 / ECS RAM Role 等）
 4. `config.json` 中的静态 `accessKeyId` / `accessKeySecret`（优先级最低，仅供开发）
 
-### 仅使用环境变量
+#### 仅使用环境变量
 
 也可以完全不写 JSON 配置，通过环境变量驱动：
 
@@ -82,7 +123,7 @@ cp config.example.json config.json
 | `ALIBABA_CLOUD_SECURITY_TOKEN` | 可选的 STS token |
 | `ALIBABA_CLOUD_CREDENTIALS_URI` | 凭证服务 URI |
 
-### 命名配置（运行时切换）
+#### 命名配置（运行时切换）
 
 如果需要在不重启 MCP Server 的情况下切换地域、endpoint、项目或身份，可以创建本地多配置文件，例如 `config.multi.json`，并通过 `MAXCOMPUTE_CATALOG_CONFIG` 指向它：
 
@@ -131,21 +172,21 @@ cp config.example.json config.json
 
 当前配置是进程级状态。运行时切换更适合 stdio / 单客户端场景。在共享的 Streamable HTTP 模式下，所有客户端共享同一个当前配置，一个客户端调用 `use_config` 会影响其他客户端。
 
-## 运行
+### 运行
 
-### stdio（默认）
+#### stdio（默认）
 
 ```bash
 uv run alibabacloud-maxcompute-mcp-server
 ```
 
-### Streamable HTTP
+#### Streamable HTTP
 
 ```bash
 uv run alibabacloud-maxcompute-mcp-server --transport http --host 127.0.0.1 --port 8000
 ```
 
-## MCP 工具
+### MCP 工具
 
 所有工具都通过 MCP text 响应返回 JSON。调用方应先检查 `success`，再读取 `data`、`summary` 或 `error`。
 
@@ -164,9 +205,9 @@ uv run alibabacloud-maxcompute-mcp-server --transport http --host 127.0.0.1 --po
 - `search_meta_data` 依赖 `namespaceId` / `MAXCOMPUTE_NAMESPACE_ID`。
 - 大结果集可通过本地 `file://` `output_uri` 流式写盘；不传时结果以内联方式返回，超过上限会被截断。
 
-## MCP 客户端接入
+### MCP 客户端接入
 
-### Cursor / Claude Code（stdio，使用配置文件）
+#### Cursor / Claude Code（stdio，使用配置文件）
 
 ```json
 {
@@ -187,7 +228,7 @@ uv run alibabacloud-maxcompute-mcp-server --transport http --host 127.0.0.1 --po
 }
 ```
 
-### Cursor / Claude Code（stdio，仅环境变量）
+#### Cursor / Claude Code（stdio，仅环境变量）
 
 ```json
 {
@@ -212,11 +253,11 @@ uv run alibabacloud-maxcompute-mcp-server --transport http --host 127.0.0.1 --po
 }
 ```
 
-### Streamable HTTP
+#### Streamable HTTP
 
 先按上文启动服务端，再将 MCP 客户端地址指向 `http://127.0.0.1:8000/mcp`。
 
-## 开发
+### 开发
 
 ```bash
 uv sync --all-extras
@@ -224,7 +265,7 @@ uv run pytest tests/ -q
 uv build
 ```
 
-### 包名与模块名
+#### 包名与模块名
 
 | 名称 | 上下文 |
 | --- | --- |
@@ -236,7 +277,8 @@ uv build
 ## 参与贡献
 
 - 这是首个开源源码版本。本阶段**不**提供 PyPI 包和 GitHub Release 构件
-- 欢迎提交 Pull Request 和 Issue。进行较大改动前请先开 Issue 讨论
+- 欢迎提交 Pull Request 和 Issue。Remote MCP 服务反馈请使用 Remote MCP issue 模板；
+  local server 代码较大改动请先开 Issue 讨论
 
 ## 开源协议
 


### PR DESCRIPTION
## Summary

- make the repository remote-first by pointing users to the hosted MaxCompute Remote MCP Server documentation
- add separate GitHub issue templates for Remote MCP service feedback and local MCP server issues
- close blank issues so reports go through the right template and redaction checklist

## Validation

- git diff --check
- manual trailing-whitespace check for README files and issue templates

## Notes

Python tests were not run because this change only updates documentation and GitHub issue templates.