### PR TITLE
fix: restore local project lookup and surface request IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Local SDK mode now requests the public CatalogAPI project view required by
+  `pyodps-catalog` 0.4, restoring `get_project` and schema-model detection.
+
 ## [0.1.4] - 2026-08-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Remote proxy failures now preserve safe CatalogAPI and Gateway Request IDs in
+  stderr diagnostics and MCP error metadata while leaving successful responses
+  unchanged.
+
 ### Fixed
 
 - Local SDK mode now requests the public CatalogAPI project view required by

--- a/README.md
+++ b/README.md
@@ -335,6 +335,14 @@ fragment. The proxy rejects redirects, ignores ambient HTTP proxy variables,
 and renews the short-lived bearer through CatalogAPI single-flight. The
 CatalogAPI operation has no business body; scope and TTL are server-owned.
 
+When CatalogAPI or the Gateway provides a Request ID, remote-mode failures
+surface that correlation value without exposing credentials: startup failures
+include it in the stderr diagnostic, JSON-RPC errors include
+`error.data.request_id`, and `isError: true` tool results without an existing
+`structuredContent.request_id` include
+`_meta["com.aliyun.maxcompute/requestId"]`. HTTP failures are logged to stderr
+with status and Request ID. Successful MCP response bodies are unchanged.
+
 ### Running
 
 #### Force local mode, stdio

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -307,6 +307,13 @@ remote URL 必须是无 userinfo、query、fragment 且路径严格为 `/mcp` �
 代理拒绝 redirect、忽略环境 HTTP proxy，并以 single-flight 方式通过 CatalogAPI
 续期短期 bearer token。CatalogAPI 接口无业务 body，scope 和 TTL 由服务端固定。
 
+CatalogAPI 或 Gateway 返回 Request ID 时，remote 模式会在不暴露凭证的前提下保留该
+排查信息：启动失败会把 Request ID 写入 stderr；JSON-RPC 错误会写入
+`error.data.request_id`；`isError: true` 的工具结果如果还没有
+`structuredContent.request_id`，则写入
+`_meta["com.aliyun.maxcompute/requestId"]`。HTTP 失败会把状态码和 Request ID 记录到
+stderr，成功的 MCP 响应体保持不变。
+
 ### 运行
 
 #### 强制 local 模式，stdio

--- a/maxcompute_catalog_mcp/remote_auth.py
+++ b/maxcompute_catalog_mcp/remote_auth.py
@@ -10,6 +10,8 @@ from typing import Any, Protocol
 from alibabacloud_tea_util import models as util_models
 from maxcompute_tea_openapi import models as openapi_models
 
+from .request_ids import request_id_from_exception, sanitize_request_id
+
 _MCP_ACCESS_TOKEN_PATH = "/api/catalog/v1alpha/mcpAccessToken"
 _EXPECTED_SCOPES = ["maxcompute:read", "maxcompute:sql"]
 _TOKEN_LIFETIME_SECONDS = 300
@@ -23,6 +25,17 @@ class CatalogTokenClient(Protocol):
     """Issue one token through the authenticated CatalogAPI path."""
 
     async def issue_access_token(self) -> object: ...
+
+
+class CatalogTokenRequestError(RuntimeError):
+    """Sanitized CatalogAPI issuance failure with optional correlation metadata."""
+
+    def __init__(self, request_id: str | None = None) -> None:
+        self.request_id = sanitize_request_id(request_id)
+        message = "CatalogAPI MCP token request failed"
+        if self.request_id is not None:
+            message = f"{message} (request_id={self.request_id})"
+        super().__init__(message)
 
 
 @dataclass(frozen=True)
@@ -73,8 +86,8 @@ class CatalogMCPAccessTokenClient:
                 request,
                 runtime,
             )
-        except Exception:  # noqa: BLE001 -- sanitize the external SDK boundary.
-            raise RuntimeError("CatalogAPI MCP token request failed") from None
+        except Exception as error:  # noqa: BLE001 -- sanitize the SDK boundary.
+            raise CatalogTokenRequestError(request_id_from_exception(error)) from None
 
 
 class CatalogAccessTokenProvider:
@@ -119,8 +132,10 @@ class CatalogAccessTokenProvider:
     async def _renew(self) -> AccessToken:
         try:
             payload = await self._client.issue_access_token()
-        except Exception:  # noqa: BLE001 -- CatalogTokenClient is a provider boundary.
-            raise RuntimeError("CatalogAPI MCP token request failed") from None
+        except CatalogTokenRequestError:
+            raise
+        except Exception as error:  # noqa: BLE001 -- provider boundary.
+            raise CatalogTokenRequestError(request_id_from_exception(error)) from None
         return self._parse_access_token(payload)
 
     @staticmethod

--- a/maxcompute_catalog_mcp/remote_proxy.py
+++ b/maxcompute_catalog_mcp/remote_proxy.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+import logging
 from collections.abc import AsyncGenerator, AsyncIterable
 from dataclasses import replace
 from typing import Any, Protocol
@@ -18,15 +20,90 @@ from mcp.shared.inbound import (
 )
 from mcp.shared.message import ClientMessageMetadata, SessionMessage
 
+from .request_ids import sanitize_request_id
 from .runtime_config import RemoteRuntimeConfig
 
 _REMOTE_INITIALIZATION_TIMEOUT_SECONDS = 10.0
+_REQUEST_ID_HEADER = "X-Request-ID"
+_REQUEST_ID_META_KEY = "com.aliyun.maxcompute/requestId"
+_LOGGER = logging.getLogger(__name__)
 
 
 class AccessTokenProvider(Protocol):
     """Return a current gateway bearer token."""
 
     async def get_access_token(self) -> str: ...
+
+
+class RemoteMCPInitializationFailure(RuntimeError):
+    """Remote initialize failure with safe gateway correlation metadata."""
+
+    def __init__(self, request_id: str) -> None:
+        self.request_id = sanitize_request_id(request_id)
+        message = "Remote MCP initialization failed"
+        if self.request_id is not None:
+            message = f"{message} (request_id={self.request_id})"
+        super().__init__(message)
+
+
+class RemoteRequestIdTracker:
+    """Correlate MCP POST responses with their gateway request IDs."""
+
+    def __init__(self) -> None:
+        self._pending: dict[int | str, str] = {}
+        self.latest_request_id: str | None = None
+
+    async def observe_response(self, response: httpx.Response) -> None:
+        """Record and safely log one gateway HTTP response."""
+
+        request_id = sanitize_request_id(response.headers.get(_REQUEST_ID_HEADER))
+        if response.status_code >= 400:
+            if request_id is None:
+                _LOGGER.warning(
+                    "Remote MCP HTTP response status=%d",
+                    response.status_code,
+                )
+            else:
+                _LOGGER.warning(
+                    "Remote MCP HTTP response status=%d request_id=%s",
+                    response.status_code,
+                    request_id,
+                )
+        elif request_id is not None:
+            _LOGGER.debug(
+                "Remote MCP HTTP response status=%d request_id=%s",
+                response.status_code,
+                request_id,
+            )
+
+        if request_id is None:
+            return
+        self.latest_request_id = request_id
+        jsonrpc_id = self._request_jsonrpc_id(response.request)
+        if jsonrpc_id is not None:
+            self._pending[jsonrpc_id] = request_id
+
+    def pop(self, jsonrpc_id: object) -> str | None:
+        """Consume the response Request ID for one exact JSON-RPC ID."""
+
+        if isinstance(jsonrpc_id, bool) or not isinstance(jsonrpc_id, int | str):
+            return None
+        return self._pending.pop(jsonrpc_id, None)
+
+    @staticmethod
+    def _request_jsonrpc_id(request: httpx.Request) -> int | str | None:
+        if request.method != "POST":
+            return None
+        try:
+            payload = json.loads(request.content)
+        except (json.JSONDecodeError, UnicodeDecodeError, httpx.RequestNotRead):
+            return None
+        if not isinstance(payload, dict):
+            return None
+        jsonrpc_id = payload.get("id")
+        if isinstance(jsonrpc_id, bool) or not isinstance(jsonrpc_id, int | str):
+            return None
+        return jsonrpc_id
 
 
 class DynamicBearerAuth(httpx.Auth):
@@ -47,9 +124,10 @@ class DynamicBearerAuth(httpx.Auth):
 class ProtocolMetadataBridge:
     """Project stdio JSON-RPC metadata onto Streamable HTTP request headers."""
 
-    def __init__(self) -> None:
+    def __init__(self, request_ids: RemoteRequestIdTracker | None = None) -> None:
         self._initialize_request_id: int | str | None = None
         self._legacy_protocol_version: str | None = None
+        self._request_ids = request_ids
 
     def prepare_outbound(self, message: SessionMessage) -> SessionMessage:
         """Attach transport metadata while preserving the JSON-RPC object."""
@@ -87,18 +165,62 @@ class ProtocolMetadataBridge:
         return message
 
     def observe_inbound(self, message: SessionMessage) -> SessionMessage:
-        """Remember the server-selected legacy version from initialize."""
+        """Remember protocol state and add HTTP correlation to failures."""
 
         payload = message.message
         if (
-            not isinstance(payload, mcp_types.JSONRPCResponse)
-            or payload.id != self._initialize_request_id
+            isinstance(payload, mcp_types.JSONRPCResponse)
+            and payload.id == self._initialize_request_id
         ):
+            protocol_version = payload.result.get("protocolVersion")
+            if isinstance(protocol_version, str) and protocol_version:
+                self._legacy_protocol_version = protocol_version
+
+        if not isinstance(payload, mcp_types.JSONRPCResponse | mcp_types.JSONRPCError):
             return message
-        protocol_version = payload.result.get("protocolVersion")
-        if isinstance(protocol_version, str) and protocol_version:
-            self._legacy_protocol_version = protocol_version
+        request_id = (
+            self._request_ids.pop(payload.id) if self._request_ids is not None else None
+        )
+        if request_id is None:
+            return message
+        if isinstance(payload, mcp_types.JSONRPCError):
+            self._add_jsonrpc_error_request_id(payload.error, request_id)
+        elif payload.result.get("isError") is True:
+            self._add_tool_error_request_id(payload.result, request_id)
         return message
+
+    @staticmethod
+    def _add_jsonrpc_error_request_id(
+        error: mcp_types.ErrorData,
+        request_id: str,
+    ) -> None:
+        data = error.data
+        if isinstance(data, dict):
+            if "request_id" not in data:
+                error.data = {**data, "request_id": request_id}
+            return
+        if data is None:
+            error.data = {"request_id": request_id}
+            return
+        error.data = {"details": data, "request_id": request_id}
+
+    @staticmethod
+    def _add_tool_error_request_id(
+        result: dict[str, Any],
+        request_id: str,
+    ) -> None:
+        structured_content = result.get("structuredContent")
+        if (
+            isinstance(structured_content, dict)
+            and sanitize_request_id(structured_content.get("request_id")) is not None
+        ):
+            return
+        metadata = result.get("_meta")
+        if isinstance(metadata, dict):
+            if _REQUEST_ID_META_KEY not in metadata:
+                metadata[_REQUEST_ID_META_KEY] = request_id
+            return
+        result["_meta"] = {_REQUEST_ID_META_KEY: request_id}
 
     @staticmethod
     def _self_describing_version(params: object) -> str | None:
@@ -140,23 +262,32 @@ async def probe_remote_mcp(
     from mcp import ClientSession
     from mcp.client.streamable_http import streamable_http_client
 
-    with anyio.fail_after(_REMOTE_INITIALIZATION_TIMEOUT_SECONDS):
-        async with (
-            httpx.AsyncClient(
-                auth=DynamicBearerAuth(token_provider),
-                follow_redirects=False,
-                trust_env=False,
-            ) as mcp_client,
-            streamable_http_client(
-                config.url,
-                http_client=mcp_client,
-            ) as (remote_read, remote_write),
-            ClientSession(
-                remote_read,
-                remote_write,
-            ) as session,
-        ):
-            await session.initialize()
+    request_ids = RemoteRequestIdTracker()
+    try:
+        with anyio.fail_after(_REMOTE_INITIALIZATION_TIMEOUT_SECONDS):
+            async with (
+                httpx.AsyncClient(
+                    auth=DynamicBearerAuth(token_provider),
+                    event_hooks={"response": [request_ids.observe_response]},
+                    follow_redirects=False,
+                    trust_env=False,
+                ) as mcp_client,
+                streamable_http_client(
+                    config.url,
+                    http_client=mcp_client,
+                ) as (remote_read, remote_write),
+                ClientSession(
+                    remote_read,
+                    remote_write,
+                ) as session,
+            ):
+                await session.initialize()
+    except Exception:
+        if request_ids.latest_request_id is not None:
+            raise RemoteMCPInitializationFailure(
+                request_ids.latest_request_id
+            ) from None
+        raise
 
 
 async def relay_client_messages(
@@ -190,10 +321,11 @@ async def relay_bidirectional(
     local_write: Any,
     remote_read: Any,
     remote_write: Any,
+    request_ids: RemoteRequestIdTracker | None = None,
 ) -> None:
     """Relay both MCP directions until either transport closes or fails."""
 
-    bridge = ProtocolMetadataBridge()
+    bridge = ProtocolMetadataBridge(request_ids)
     async with anyio.create_task_group() as tasks:
 
         async def relay_until_closed(relay: Any, source: Any, target: Any) -> None:
@@ -230,9 +362,11 @@ async def _run_remote_proxy_with_provider(
     from mcp.client.streamable_http import streamable_http_client
     from mcp.server.stdio import stdio_server
 
+    request_ids = RemoteRequestIdTracker()
     async with (
         httpx.AsyncClient(
             auth=DynamicBearerAuth(token_provider),
+            event_hooks={"response": [request_ids.observe_response]},
             follow_redirects=False,
             trust_env=False,
         ) as mcp_client,
@@ -250,4 +384,5 @@ async def _run_remote_proxy_with_provider(
             local_write,
             remote_read,
             remote_write,
+            request_ids,
         )

--- a/maxcompute_catalog_mcp/request_ids.py
+++ b/maxcompute_catalog_mcp/request_ids.py
@@ -1,0 +1,44 @@
+"""Safe handling for untrusted provider and gateway request IDs."""
+
+from __future__ import annotations
+
+from typing import Any
+
+_MAX_REQUEST_ID_CHARS = 256
+_MISSING_REQUEST_ID_VALUES = frozenset({"none", "null"})
+_REQUEST_ID_DATA_KEYS = ("request_id", "requestId", "RequestId")
+
+
+def sanitize_request_id(value: object) -> str | None:
+    """Return one log-safe printable ASCII request ID, if present."""
+
+    if not isinstance(value, str):
+        return None
+    candidate = value.strip()
+    if (
+        not candidate
+        or len(candidate) > _MAX_REQUEST_ID_CHARS
+        or candidate.casefold() in _MISSING_REQUEST_ID_VALUES
+        or any(character < " " or character > "~" for character in candidate)
+    ):
+        return None
+    return candidate
+
+
+def request_id_from_exception(error: BaseException) -> str | None:
+    """Extract only an explicit request ID from a provider exception."""
+
+    try:
+        request_id = sanitize_request_id(getattr(error, "request_id", None))
+        data: Any = getattr(error, "data", None)
+    except Exception:  # noqa: BLE001 -- exception objects are an external boundary.
+        return None
+    if request_id is not None:
+        return request_id
+    if not isinstance(data, dict):
+        return None
+    for key in _REQUEST_ID_DATA_KEYS:
+        request_id = sanitize_request_id(data.get(key))
+        if request_id is not None:
+            return request_id
+    return None

--- a/maxcompute_catalog_mcp/server.py
+++ b/maxcompute_catalog_mcp/server.py
@@ -17,6 +17,7 @@ from .remote_auth import (
     CatalogAccessTokenProvider,
     CatalogMCPAccessTokenClient,
 )
+from .request_ids import request_id_from_exception, sanitize_request_id
 from .runtime_config import (
     RemoteRuntimeConfig,
     RuntimeConfig,
@@ -35,6 +36,12 @@ _LOGGER = logging.getLogger(__name__)
 
 class RemoteInitializationError(RuntimeError):
     """Remote token issuance or MCP initialize failed before selection."""
+
+    def __init__(self, message: str, request_id: str | None = None) -> None:
+        self.request_id = sanitize_request_id(request_id)
+        if self.request_id is not None:
+            message = f"{message} (request_id={self.request_id})"
+        super().__init__(message)
 
 
 class LocalDependenciesMissingError(RuntimeError):
@@ -316,14 +323,18 @@ async def _initialize_remote_mcp(
 
     try:
         await token_provider.get_access_token()
-    except Exception:  # noqa: BLE001 -- normalize SDK and transport failures.
+    except Exception as error:  # noqa: BLE001 -- normalize SDK failures.
         raise RemoteInitializationError(
-            "Remote MCP token issuance failed during initialization"
+            "Remote MCP token issuance failed during initialization",
+            request_id_from_exception(error),
         ) from None
     try:
         await _probe_remote_mcp(config, token_provider)
-    except Exception:  # noqa: BLE001 -- normalize remote transport failures.
-        raise RemoteInitializationError("Remote MCP initialization failed") from None
+    except Exception as error:  # noqa: BLE001 -- normalize transport failures.
+        raise RemoteInitializationError(
+            "Remote MCP initialization failed",
+            request_id_from_exception(error),
+        ) from None
 
 
 async def _run_forced_remote_stdio(
@@ -351,10 +362,19 @@ async def _run_default_stdio(
             )
             await _initialize_remote_mcp(remote, token_provider)
         except Exception as error:  # noqa: BLE001 -- default mode must fall back.
-            _LOGGER.warning(
-                "Remote MCP initialization failed; falling back to local mode (%s)",
-                type(error).__name__,
-            )
+            request_id = request_id_from_exception(error)
+            if request_id is None:
+                _LOGGER.warning(
+                    "Remote MCP initialization failed; falling back to local mode (%s)",
+                    type(error).__name__,
+                )
+            else:
+                _LOGGER.warning(
+                    "Remote MCP initialization failed; falling back to local mode "
+                    "(%s, request_id=%s)",
+                    type(error).__name__,
+                    request_id,
+                )
         else:
             await _run_remote_proxy(remote, token_provider)
             return

--- a/maxcompute_catalog_mcp/tools.py
+++ b/maxcompute_catalog_mcp/tools.py
@@ -278,7 +278,7 @@ class Tools(
         """
         if project not in self._schema_enabled_cache:
             try:
-                resp = self.sdk.client.get_project(project_id=project)
+                resp = self._get_project(project)
                 m = resp.to_map() if hasattr(resp, "to_map") else resp
                 enabled = m.get("schemaEnabled")
                 # schemaEnabled absent on older API versions → assume 3-level

--- a/maxcompute_catalog_mcp/tools_catalog.py
+++ b/maxcompute_catalog_mcp/tools_catalog.py
@@ -20,6 +20,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_PROJECT_VIEW_BASIC = "BASIC"
+
 
 class CatalogMixin:
     """Mixin providing catalog explorer and metadata search handlers.
@@ -35,6 +37,14 @@ class CatalogMixin:
 
         def _is_schema_enabled(self, project: str) -> bool: ...
 
+    def _get_project(self, project: str) -> Any:
+        """Fetch the public project view required by pyodps-catalog 0.4."""
+
+        return self.sdk.client.get_project(
+            project_id=project,
+            view=_PROJECT_VIEW_BASIC,
+        )
+
     def list_projects(self, args: dict[str, Any]) -> dict[str, Any]:
         page_size = opt_int(args, "pageSize", 100)
         token = opt_arg(args, "token")
@@ -46,7 +56,7 @@ class CatalogMixin:
 
     def get_project(self, args: dict[str, Any]) -> dict[str, Any]:
         project = require_arg(args, "project", "Project name cannot be empty")
-        resp = self.sdk.client.get_project(project_id=project)
+        resp = self._get_project(project)
         m = resp.to_map() if hasattr(resp, "to_map") else resp
         return mcp_ok_result(m)
 

--- a/tests/test_remote_auth.py
+++ b/tests/test_remote_auth.py
@@ -7,12 +7,15 @@ from dataclasses import dataclass, field
 from unittest.mock import AsyncMock
 
 import pytest
+from alibabacloud_tea_openapi.exceptions import ClientException
 
 from maxcompute_catalog_mcp.remote_auth import (
     AccessToken,
     CatalogAccessTokenProvider,
     CatalogMCPAccessTokenClient,
+    CatalogTokenRequestError,
 )
+from maxcompute_catalog_mcp.request_ids import request_id_from_exception
 
 
 def _valid_response(token: str = "mcpc_fixture-token") -> dict[str, object]:
@@ -206,3 +209,67 @@ def test_catalog_sdk_adapter_sanitizes_provider_and_http_errors() -> None:
         assert "fixture-secret" not in str(exc_info.value)
 
     asyncio.run(scenario())
+
+
+def test_catalog_sdk_adapter_preserves_only_safe_provider_request_id() -> None:
+    """Catalog failures retain correlation metadata without leaking SDK details."""
+
+    async def scenario() -> None:
+        catalog_client = AsyncMock()
+        catalog_client.call_api_async.side_effect = ClientException(
+            status_code=403,
+            code="Forbidden",
+            message="fixture-secret-ak-and-token",
+            request_id="catalog-request-403",
+        )
+        provider = CatalogAccessTokenProvider(
+            client=CatalogMCPAccessTokenClient(catalog_client),
+        )
+
+        with pytest.raises(CatalogTokenRequestError) as exc_info:
+            await provider.get_access_token()
+
+        assert exc_info.value.request_id == "catalog-request-403"
+        assert str(exc_info.value) == (
+            "CatalogAPI MCP token request failed (request_id=catalog-request-403)"
+        )
+        assert "fixture-secret" not in str(exc_info.value)
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    ("data", "expected"),
+    [
+        ({"requestId": "catalog-lower-camel"}, "catalog-lower-camel"),
+        ({"RequestId": "catalog-upper-camel"}, "catalog-upper-camel"),
+        (
+            {"request_id": "bad\nvalue", "requestId": "catalog-fallback"},
+            "catalog-fallback",
+        ),
+        ({"message": "no correlation metadata"}, None),
+    ],
+)
+def test_provider_request_id_extraction_supports_explicit_sdk_data_shapes(
+    data: dict[str, object],
+    expected: str | None,
+) -> None:
+    """Known Alibaba Cloud SDK data keys are accepted without parsing messages."""
+
+    error = RuntimeError("provider detail must stay private")
+    error.data = data
+
+    assert request_id_from_exception(error) == expected
+
+
+def test_provider_request_id_extraction_tolerates_hostile_exception_properties() -> (
+    None
+):
+    """A broken external exception object cannot mask the sanitized failure."""
+
+    class HostileProviderError(RuntimeError):
+        @property
+        def request_id(self) -> str:
+            raise RuntimeError("property access failed")
+
+    assert request_id_from_exception(HostileProviderError()) is None

--- a/tests/test_remote_proxy.py
+++ b/tests/test_remote_proxy.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import sys
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
@@ -18,16 +19,20 @@ from mcp.shared.message import ClientMessageMetadata, SessionMessage
 from maxcompute_catalog_mcp.remote_proxy import (
     DynamicBearerAuth,
     ProtocolMetadataBridge,
+    RemoteMCPInitializationFailure,
+    RemoteRequestIdTracker,
     _run_remote_proxy_with_provider,
     probe_remote_mcp,
     relay_client_messages,
     relay_server_messages,
 )
+from maxcompute_catalog_mcp.request_ids import sanitize_request_id
 from maxcompute_catalog_mcp.runtime_config import RemoteRuntimeConfig
 
 MODERN_PROTOCOL_VERSION = "2026-07-28"
 LEGACY_PROTOCOL_VERSION = "2025-06-18"
 PROTOCOL_VERSION_META_KEY = "io.modelcontextprotocol/protocolVersion"
+REQUEST_ID_META_KEY = "com.aliyun.maxcompute/requestId"
 
 
 @dataclass
@@ -121,11 +126,15 @@ def test_remote_proxy_uses_exact_hardened_http_client_and_relay_wiring() -> None
         assert kwargs["auth"]._provider is provider
         assert kwargs["follow_redirects"] is False
         assert kwargs["trust_env"] is False
+        response_hooks = kwargs["event_hooks"]["response"]
+        assert len(response_hooks) == 1
+        assert isinstance(response_hooks[0].__self__, RemoteRequestIdTracker)
         relay_mock.assert_awaited_once_with(
             local_read,
             local_write,
             remote_read,
             remote_write,
+            response_hooks[0].__self__,
         )
 
     asyncio.run(scenario())
@@ -164,7 +173,10 @@ def test_remote_probe_requires_authenticated_mcp_initialize() -> None:
             assert payload["method"] == "notifications/initialized"
             return httpx.Response(202)
 
+        observed_hooks: list[object] = []
+
         def client_factory(**kwargs):
+            observed_hooks.extend(kwargs["event_hooks"]["response"])
             return real_async_client(
                 transport=httpx.MockTransport(handler),
                 **kwargs,
@@ -183,6 +195,383 @@ def test_remote_probe_requires_authenticated_mcp_initialize() -> None:
             ("initialize", "Bearer gateway-token-1"),
             ("notifications/initialized", "Bearer gateway-token-2"),
         ]
+        assert len(observed_hooks) == 1
+        assert isinstance(observed_hooks[0].__self__, RemoteRequestIdTracker)
+
+    asyncio.run(scenario())
+
+
+def test_remote_probe_failure_surfaces_sanitized_request_id(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Forced remote startup exposes the gateway correlation ID, not credentials."""
+
+    async def scenario() -> None:
+        real_async_client = httpx.AsyncClient
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            assert request.headers["Authorization"] == "Bearer gateway-token-1"
+            return httpx.Response(
+                401,
+                headers={
+                    "content-type": "application/json",
+                    "x-request-id": "gateway-request-401",
+                },
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "error": {"code": -32001, "message": "unauthorized"},
+                },
+            )
+
+        def client_factory(**kwargs):
+            return real_async_client(
+                transport=httpx.MockTransport(handler),
+                **kwargs,
+            )
+
+        with (
+            patch(
+                "maxcompute_catalog_mcp.remote_proxy.httpx.AsyncClient",
+                side_effect=client_factory,
+            ),
+            pytest.raises(
+                RemoteMCPInitializationFailure,
+                match="gateway-request-401",
+            ) as exc_info,
+        ):
+            await probe_remote_mcp(
+                RemoteRuntimeConfig(url="https://gateway.example.com/mcp"),
+                RotatingTokenProvider(),
+            )
+
+        assert exc_info.value.request_id == "gateway-request-401"
+
+    caplog.set_level(logging.DEBUG)
+    asyncio.run(scenario())
+
+    assert "status=401" in caplog.text
+    assert "request_id=gateway-request-401" in caplog.text
+    assert "gateway-token-1" not in caplog.text
+    assert "Authorization" not in caplog.text
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        None,
+        "",
+        " ",
+        "request\nid",
+        "request\x00id",
+        "请求-id",
+        "r" * 257,
+        42,
+        "None",
+    ],
+)
+def test_request_id_sanitizer_rejects_untrusted_values(value: object) -> None:
+    """Untrusted response metadata cannot inject logs or oversized errors."""
+
+    assert sanitize_request_id(value) is None
+
+
+def test_request_id_tracker_logs_success_only_at_debug(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Successful request IDs remain available for diagnostics without warning."""
+
+    async def scenario() -> None:
+        tracker = RemoteRequestIdTracker()
+        request = httpx.Request(
+            "POST",
+            "https://gateway.example.com/mcp",
+            json={"jsonrpc": "2.0", "id": 7, "method": "tools/list"},
+        )
+        await tracker.observe_response(
+            httpx.Response(
+                200,
+                headers={"x-request-id": "gateway-request-200"},
+                request=request,
+            )
+        )
+
+        assert tracker.pop(7) == "gateway-request-200"
+
+    caplog.set_level(logging.DEBUG)
+    asyncio.run(scenario())
+
+    assert "DEBUG" in caplog.text
+    assert "status=200" in caplog.text
+    assert "request_id=gateway-request-200" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("method", "content"),
+    [
+        ("GET", b""),
+        ("POST", b"not-json"),
+        ("POST", b"[]"),
+        ("POST", b'{"jsonrpc":"2.0","id":true,"method":"tools/list"}'),
+    ],
+)
+def test_request_id_tracker_ignores_uncorrelatable_http_responses(
+    method: str,
+    content: bytes,
+) -> None:
+    """Non-request traffic is logged but never assigned to a JSON-RPC response."""
+
+    async def scenario() -> None:
+        tracker = RemoteRequestIdTracker()
+        request = httpx.Request(
+            method,
+            "https://gateway.example.com/mcp",
+            content=content,
+        )
+        await tracker.observe_response(
+            httpx.Response(
+                200,
+                headers={"x-request-id": "gateway-uncorrelated"},
+                request=request,
+            )
+        )
+
+        assert tracker.latest_request_id == "gateway-uncorrelated"
+        assert tracker.pop(True) is None
+        assert tracker.pop(None) is None
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    ("original_data", "expected_data"),
+    [
+        (None, {"request_id": "gateway-error-1"}),
+        (
+            {"reason": "denied"},
+            {"reason": "denied", "request_id": "gateway-error-1"},
+        ),
+        (
+            "provider detail",
+            {"details": "provider detail", "request_id": "gateway-error-1"},
+        ),
+        (
+            {"request_id": "backend-request"},
+            {"request_id": "backend-request"},
+        ),
+    ],
+)
+def test_jsonrpc_errors_include_correlated_gateway_request_id(
+    original_data: object,
+    expected_data: dict[str, object],
+) -> None:
+    """Every JSON-RPC error carries the matching HTTP request ID when available."""
+
+    async def scenario() -> None:
+        tracker = RemoteRequestIdTracker()
+        for request_id, gateway_request_id in (
+            (1, "gateway-error-1"),
+            ("1", "gateway-error-string-1"),
+        ):
+            request = httpx.Request(
+                "POST",
+                "https://gateway.example.com/mcp",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "method": "tools/call",
+                },
+            )
+            await tracker.observe_response(
+                httpx.Response(
+                    400,
+                    headers={"x-request-id": gateway_request_id},
+                    request=request,
+                )
+            )
+
+        bridge = ProtocolMetadataBridge(tracker)
+        string_id_error = SessionMessage(
+            mcp_types.JSONRPCError(
+                jsonrpc="2.0",
+                id="1",
+                error=mcp_types.ErrorData(
+                    code=-32600,
+                    message="invalid request",
+                ),
+            )
+        )
+        bridge.observe_inbound(string_id_error)
+        assert string_id_error.message.error.data == {
+            "request_id": "gateway-error-string-1"
+        }
+
+        error = SessionMessage(
+            mcp_types.JSONRPCError(
+                jsonrpc="2.0",
+                id=1,
+                error=mcp_types.ErrorData(
+                    code=-32600,
+                    message="invalid request",
+                    data=original_data,
+                ),
+            )
+        )
+
+        assert bridge.observe_inbound(error) is error
+        assert error.message.error.data == expected_data
+        assert tracker.pop(1) is None
+
+    asyncio.run(scenario())
+
+
+def test_tool_errors_use_result_metadata_without_overwriting_existing_ids() -> None:
+    """Tool error results expose transport IDs unless the tool already supplied one."""
+
+    async def scenario() -> None:
+        tracker = RemoteRequestIdTracker()
+        for request_id in (2, 3, 4, 5):
+            request = httpx.Request(
+                "POST",
+                "https://gateway.example.com/mcp",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "method": "tools/call",
+                },
+            )
+            await tracker.observe_response(
+                httpx.Response(
+                    200,
+                    headers={"x-request-id": f"gateway-tool-{request_id}"},
+                    request=request,
+                )
+            )
+
+        bridge = ProtocolMetadataBridge(tracker)
+        without_body_id = SessionMessage(
+            mcp_types.JSONRPCResponse(
+                jsonrpc="2.0",
+                id=2,
+                result={
+                    "content": [{"type": "text", "text": "failed"}],
+                    "isError": True,
+                },
+            )
+        )
+        with_body_id = SessionMessage(
+            mcp_types.JSONRPCResponse(
+                jsonrpc="2.0",
+                id=3,
+                result={
+                    "content": [{"type": "text", "text": "failed"}],
+                    "structuredContent": {"request_id": "backend-tool-request"},
+                    "isError": True,
+                },
+            )
+        )
+        with_metadata = SessionMessage(
+            mcp_types.JSONRPCResponse(
+                jsonrpc="2.0",
+                id=4,
+                result={
+                    "_meta": {"existing": "metadata"},
+                    "content": [{"type": "text", "text": "failed"}],
+                    "isError": True,
+                },
+            )
+        )
+        with_transport_id = SessionMessage(
+            mcp_types.JSONRPCResponse(
+                jsonrpc="2.0",
+                id=5,
+                result={
+                    "_meta": {REQUEST_ID_META_KEY: "original-transport-request"},
+                    "content": [{"type": "text", "text": "failed"}],
+                    "isError": True,
+                },
+            )
+        )
+
+        bridge.observe_inbound(without_body_id)
+        bridge.observe_inbound(with_body_id)
+        bridge.observe_inbound(with_metadata)
+        bridge.observe_inbound(with_transport_id)
+
+        assert without_body_id.message.result["_meta"] == {
+            REQUEST_ID_META_KEY: "gateway-tool-2"
+        }
+        assert "_meta" not in with_body_id.message.result
+        assert with_body_id.message.result["structuredContent"] == {
+            "request_id": "backend-tool-request"
+        }
+        assert with_metadata.message.result["_meta"] == {
+            "existing": "metadata",
+            REQUEST_ID_META_KEY: "gateway-tool-4",
+        }
+        assert with_transport_id.message.result["_meta"] == {
+            REQUEST_ID_META_KEY: "original-transport-request"
+        }
+
+    asyncio.run(scenario())
+
+
+def test_success_and_headerless_responses_remain_unchanged() -> None:
+    """The proxy adds metadata only to failures with a usable correlation ID."""
+
+    async def scenario() -> None:
+        tracker = RemoteRequestIdTracker()
+        success_request = httpx.Request(
+            "POST",
+            "https://gateway.example.com/mcp",
+            json={"jsonrpc": "2.0", "id": 4, "method": "tools/call"},
+        )
+        await tracker.observe_response(
+            httpx.Response(
+                200,
+                headers={"x-request-id": "gateway-success-4"},
+                request=success_request,
+            )
+        )
+        headerless_request = httpx.Request(
+            "POST",
+            "https://gateway.example.com/mcp",
+            json={"jsonrpc": "2.0", "id": 5, "method": "tools/call"},
+        )
+        await tracker.observe_response(httpx.Response(500, request=headerless_request))
+        bridge = ProtocolMetadataBridge(tracker)
+        success_result = {
+            "content": [{"type": "text", "text": "ok"}],
+            "isError": False,
+        }
+        success = SessionMessage(
+            mcp_types.JSONRPCResponse(
+                jsonrpc="2.0",
+                id=4,
+                result=success_result.copy(),
+            )
+        )
+        headerless_error = SessionMessage(
+            mcp_types.JSONRPCError(
+                jsonrpc="2.0",
+                id=5,
+                error=mcp_types.ErrorData(code=-32603, message="failed"),
+            )
+        )
+
+        bridge.observe_inbound(success)
+        bridge.observe_inbound(headerless_error)
+        notification = SessionMessage(
+            mcp_types.JSONRPCNotification(
+                jsonrpc="2.0",
+                method="notifications/progress",
+            )
+        )
+        assert bridge.observe_inbound(notification) is notification
+
+        assert success.message.result == success_result
+        assert headerless_error.message.error.data is None
+        assert tracker.pop(4) is None
 
     asyncio.run(scenario())
 
@@ -411,12 +800,17 @@ def test_streamable_http_400_jsonrpc_error_returns_without_timeout() -> None:
     async def scenario() -> None:
         from mcp.client.streamable_http import streamable_http_client
 
+        request_ids = RemoteRequestIdTracker()
+
         async def handler(request: httpx.Request) -> httpx.Response:
             assert request.headers["mcp-protocol-version"] == MODERN_PROTOCOL_VERSION
             assert request.headers["mcp-method"] == "server/discover"
             return httpx.Response(
                 400,
-                headers={"content-type": "application/json"},
+                headers={
+                    "content-type": "application/json",
+                    "x-request-id": "gateway-invalid-request-1",
+                },
                 json={
                     "jsonrpc": "2.0",
                     "id": 1,
@@ -427,6 +821,7 @@ def test_streamable_http_400_jsonrpc_error_returns_without_timeout() -> None:
         async with (
             httpx.AsyncClient(
                 transport=httpx.MockTransport(handler),
+                event_hooks={"response": [request_ids.observe_response]},
                 follow_redirects=False,
                 trust_env=False,
             ) as client,
@@ -445,14 +840,17 @@ def test_streamable_http_400_jsonrpc_error_returns_without_timeout() -> None:
                     }
                 },
             )
-            await write_stream.send(
-                ProtocolMetadataBridge().prepare_outbound(SessionMessage(request))
-            )
+            bridge = ProtocolMetadataBridge(request_ids)
+            await write_stream.send(bridge.prepare_outbound(SessionMessage(request)))
             with anyio.fail_after(1):
                 received = await read_stream.receive()
+            bridge.observe_inbound(received)
 
             assert isinstance(received.message, mcp_types.JSONRPCError)
             assert received.message.id == 1
             assert received.message.error.code == -32600
+            assert received.message.error.data == {
+                "request_id": "gateway-invalid-request-1"
+            }
 
     asyncio.run(scenario())

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -13,6 +13,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from maxcompute_catalog_mcp.config import MaxComputeCatalogConfig
+from maxcompute_catalog_mcp.remote_auth import CatalogTokenRequestError
+from maxcompute_catalog_mcp.remote_proxy import RemoteMCPInitializationFailure
 from maxcompute_catalog_mcp.runtime_config import (
     RemoteRuntimeConfig,
     RuntimeConfig,
@@ -299,6 +301,39 @@ class TestDefaultMode:
         remote_mock.assert_not_awaited()
         local_mock.assert_awaited_once_with(local_tools)
 
+    def test_default_fallback_logs_remote_request_id(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Default mode keeps the gateway correlation ID in its fallback log."""
+
+        provider = MagicMock()
+        provider.get_access_token = AsyncMock(return_value="catalog-token")
+        local_tools = MagicMock()
+        with (
+            patch(
+                "maxcompute_catalog_mcp.server.build_remote_token_provider",
+                return_value=provider,
+            ),
+            patch(
+                "maxcompute_catalog_mcp.server._probe_remote_mcp",
+                new_callable=AsyncMock,
+                side_effect=RemoteMCPInitializationFailure("gateway-initialize-403"),
+            ),
+            patch(
+                "maxcompute_catalog_mcp.server.build_tools",
+                return_value=local_tools,
+            ),
+            patch(
+                "maxcompute_catalog_mcp.server._run_stdio",
+                new_callable=AsyncMock,
+            ),
+        ):
+            asyncio.run(_run_default_stdio(self._runtime(), None))
+
+        assert "falling back to local mode" in caplog.text
+        assert "request_id=gateway-initialize-403" in caplog.text
+
     def test_token_refresh_after_initialization_does_not_probe_again(self) -> None:
         runtime = self._runtime()
         provider = MagicMock()
@@ -411,6 +446,42 @@ def test_token_failure_does_not_probe_remote_endpoint() -> None:
         asyncio.run(_initialize_remote_mcp(config, provider))
 
     probe_mock.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("stage", "request_id"),
+    [
+        ("token", "catalog-token-403"),
+        ("initialize", "gateway-initialize-401"),
+    ],
+)
+def test_remote_initialization_preserves_request_id_from_each_failure_stage(
+    stage: str,
+    request_id: str,
+) -> None:
+    """Forced remote errors retain CatalogAPI and gateway correlation IDs."""
+
+    config = RemoteRuntimeConfig(url="https://gateway.example.com/mcp")
+    provider = MagicMock()
+    provider.get_access_token = AsyncMock(return_value="catalog-token")
+    probe_side_effect: Exception | None = None
+    if stage == "token":
+        provider.get_access_token.side_effect = CatalogTokenRequestError(request_id)
+    else:
+        probe_side_effect = RemoteMCPInitializationFailure(request_id)
+
+    with (
+        patch(
+            "maxcompute_catalog_mcp.server._probe_remote_mcp",
+            new_callable=AsyncMock,
+            side_effect=probe_side_effect,
+        ),
+        pytest.raises(RemoteInitializationError) as exc_info,
+    ):
+        asyncio.run(_initialize_remote_mcp(config, provider))
+
+    assert exc_info.value.request_id == request_id
+    assert f"request_id={request_id}" in str(exc_info.value)
 
 
 @patch("maxcompute_catalog_mcp.server.build_catalog_client_set")

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -43,6 +43,10 @@ def test_get_project(tools: Tools) -> None:
     )
     data = _data(payload)
     assert data.get("projectId") == "p1"
+    tools.sdk.client.get_project.assert_called_once_with(
+        project_id="p1",
+        view="BASIC",
+    )
 
 
 def test_get_project_missing_project_raises() -> None:
@@ -852,7 +856,10 @@ def test_is_schema_enabled_caches_result() -> None:
     tools = Tools(sdk=sdk, default_project="p2", namespace_id="")
     assert tools._is_schema_enabled("p2") is False
     assert tools._is_schema_enabled("p2") is False
-    sdk.client.get_project.assert_called_once_with(project_id="p2")
+    sdk.client.get_project.assert_called_once_with(
+        project_id="p2",
+        view="BASIC",
+    )
 
 
 def test_is_schema_enabled_defaults_true_on_error() -> None:


### PR DESCRIPTION
## Summary

- restore local `get_project` and schema-enabled detection with the public `BASIC` CatalogAPI view required by `pyodps-catalog` 0.4
- correlate remote Gateway `X-Request-ID` response headers with concurrent JSON-RPC requests
- include available Request IDs in JSON-RPC errors, tool error metadata, startup diagnostics, and safe stderr logs
- preserve successful remote responses and existing tool-provided request IDs unchanged
- retain only sanitized printable ASCII Request IDs; never log Authorization, AK/SK, STS, OAuth, or `mcpc_` bearer values

## Verification

- Python 3.10: 703 passed, 223 skipped
- Python 3.11: 703 passed, 223 skipped
- Python 3.12: 703 passed, 223 skipped
- line coverage: 95.28%
- branch coverage: 90.84%
- Ruff, format, mypy, and `uv lock --check` passed
- `pip-audit --strict`: no known vulnerabilities
- wheel/sdist build, Twine metadata, wheel contents, remote-first/local install smoke tests passed
- built wheel verified with MCP 2.1.1
- real `mc-schema` local-mode `get_project` E2E passed
