### PR TITLE
release: v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.1.5] - 2026-08-26
+
 ### Added
 
 - Remote proxy failures now preserve safe CatalogAPI and Gateway Request IDs in
@@ -49,6 +51,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Rule-based public and VPC endpoint derivation for Mainland China and
   international Regions without a fixed Region registry.
 
-[Unreleased]: https://github.com/aliyun/alibabacloud-maxcompute-mcp-server/compare/v0.1.4...HEAD
+[Unreleased]: https://github.com/aliyun/alibabacloud-maxcompute-mcp-server/compare/v0.1.5...HEAD
+[0.1.5]: https://github.com/aliyun/alibabacloud-maxcompute-mcp-server/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/aliyun/alibabacloud-maxcompute-mcp-server/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/aliyun/alibabacloud-maxcompute-mcp-server/compare/v0.1.2...v0.1.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "alibabacloud-maxcompute-mcp-server"
-version = "0.1.4"
+version = "0.1.5"
 description = "MCP (Model Context Protocol) server for Alibaba Cloud MaxCompute — list projects/schemas/tables, search metadata, execute SQL, and manage instances via Catalog API and PyODPS."
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -220,7 +220,7 @@ wheels = [
 
 [[package]]
 name = "alibabacloud-maxcompute-mcp-server"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- bump the package version to 0.1.5
- archive the request-ID and local project lookup changes in the changelog
- synchronize the lockfile package version

## Verification

- Python 3.10: 703 passed, 223 skipped; line 95.28%, branch 90.84%
- Python 3.11: 703 passed, 223 skipped
- Python 3.12: 703 passed, 223 skipped
- Ruff, format, mypy, and uv lock checks passed
- pip-audit found no known vulnerabilities in the locked dependency set
- sdist/wheel, Twine, wheel contents, remote-first install, and local-extra install smoke checks passed