### PR TITLE
feat: support remote Streamable HTTP proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- `default` and `remote` modes now expose a transparent Streamable HTTP proxy
+  for `POST`, `GET`, and `DELETE` with JSON, SSE, session resumption, and
+  per-request token lookup and single-flight CatalogAPI renewal.
+- Remote forwarding preserves MRTR state and input fields, progress
+  notifications, unknown future MCP payload fields, and `Mcp-*` extension
+  headers. Non-error Streamable HTTP messages remain byte-for-byte unchanged.
+
 ## [0.1.5] - 2026-08-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![English](https://img.shields.io/badge/lang-English-blue)](README.md)
 [![中文](https://img.shields.io/badge/lang-中文-red)](README_ZH.md)
 
-A local [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) launcher for Alibaba Cloud [MaxCompute](https://www.alibabacloud.com/product/maxcompute). It can run the original SDK-backed server (`local` mode) or act as a transparent stdio proxy to the hosted MaxCompute MCP service (`remote` mode).
+A local [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) launcher for Alibaba Cloud [MaxCompute](https://www.alibabacloud.com/product/maxcompute). It can run the original SDK-backed server (`local` mode) or act as a transparent stdio or Streamable HTTP proxy to the hosted MaxCompute MCP service (`remote` mode).
 
 > [!IMPORTANT]
 > MaxCompute Remote MCP Server is the recommended way to use MaxCompute MCP.
@@ -22,7 +22,7 @@ A local [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) launche
 ## Features
 
 - **Backward-compatible configuration**: existing FE/Catalog endpoints determine Region and public/VPC network; simple `region` + `network` config derives FE, Catalog, and MCP endpoints without a Region registry.
-- **Transparent remote mode**: stdio MCP messages are relayed to the hosted Streamable HTTP endpoint without rebuilding or renaming the remote tool surface.
+- **Transparent remote mode**: stdio and Streamable HTTP MCP messages are relayed to the hosted Streamable HTTP endpoint without rebuilding or renaming the remote tool surface. MRTR, progress notifications, and future MCP fields remain intact.
 - **Current protocol support**: MCP Python SDK 2.x preserves modern `2026-07-28` request metadata and routing headers while retaining legacy initialize compatibility.
 - **Standard CatalogAPI authentication**: the remote proxy signs the bodyless `mcpAccessToken` operation with the existing credential provider and resolves current AK/STS/ECS RAM Role credentials again on renewal.
 - **Credential isolation**: only a short-lived `mcpc_` bearer is sent to the Gateway; AccessKey secrets and STS credentials never enter MCP messages or URLs, and a selected remote session never falls back to the local SDK.
@@ -61,16 +61,17 @@ incidents, production outages, vulnerabilities, or confidential data cases.
 The launcher defaults to `default` for upgrades from old configurations. It
 derives the Region and public/VPC network from the selected legacy FE and
 Catalog endpoints, or uses an explicit `region` plus `network` simple config.
-When this process uses stdio and Region/network can be determined, it obtains a
-CatalogAPI token and authenticates the one regional MCP endpoint with
-`initialize`. Token issuance or remote initialization failure falls back to the
-original local implementation. Use `--mode local` to pin that implementation.
+When Region/network can be determined, the process obtains a CatalogAPI token
+and authenticates the one regional MCP endpoint with `initialize`. This startup
+selection applies to both stdio and Streamable HTTP. Token issuance or remote
+initialization failure falls back to the original local implementation. Use
+`--mode local` to pin that implementation.
 
 | Mode | MCP path | Backend | Transport exposed by this process |
 | --- | --- | --- | --- |
-| `default` | Probe remote at startup, then select one path | Remote MCP first; local SDK on initialization failure | stdio; non-stdio stays local |
+| `default` | Probe remote at startup, then select one path | Remote MCP first; local SDK on initialization failure | stdio or Streamable HTTP |
 | `local` | MCP client → this process → local SDK | MaxCompute SDK / CatalogAPI | stdio or Streamable HTTP |
-| `remote` | MCP client → this process → hosted Gateway | Remote MCP Streamable HTTP | stdio only |
+| `remote` | MCP client → this process → hosted Gateway | Remote MCP Streamable HTTP | stdio or Streamable HTTP |
 
 Explicit `remote` mode is fail-closed: CatalogAPI issuance, MCP initialize,
 token renewal, or Gateway transport failures terminate the remote flow.
@@ -93,7 +94,7 @@ The launcher needs:
 - The remote proxy obtains a 300-second `mcpc_` token through the standard
   signed CatalogAPI operation and stores no refresh token.
 - MCP Python SDK 2.x is installed from the lockfile; modern `2026-07-28` and
-  negotiated legacy stdio clients are both supported.
+  negotiated legacy clients are both supported.
 
 ### Installation
 
@@ -299,9 +300,9 @@ remote, and explicit `region`/`network` values that contradict a recognized
 endpoint are rejected as invalid configuration.
 
 A VPC configuration never selects public MCP or crosses Regions. Custom or
-historical endpoints with no verifiable Region/network, conflicting FE/Catalog
-evidence, or a local HTTP transport stay on legacy local behavior under
-`default`; explicit `remote` mode fails closed.
+historical endpoints with no verifiable Region/network or conflicting
+FE/Catalog evidence stay on legacy local behavior under `default`; explicit
+`remote` mode fails closed.
 
 Endpoint naming is determined only by Region: Mainland China Regions (`cn-*`,
 except `cn-hongkong`) use `mcp`, while `cn-hongkong` and every other overseas
@@ -335,6 +336,15 @@ fragment. The proxy rejects redirects, ignores ambient HTTP proxy variables,
 and renews the short-lived bearer through CatalogAPI single-flight. The
 CatalogAPI operation has no business body; scope and TTL are server-owned.
 
+The Streamable HTTP proxy forwards `POST`, `GET`, and `DELETE`, including JSON
+and Server-Sent Events (SSE). It preserves request body bytes, non-error remote
+messages, session and resumption headers, all `Mcp-*` extension headers, MRTR
+state and input fields, progress notifications, and unknown future MCP fields.
+The stdio bridge may re-encode JSON, but it preserves MCP fields and values. The
+proxy discards downstream `Authorization` and `Cookie` headers, replaces
+authorization with the current CatalogAPI token, and validates `Host` and
+`Origin` before contacting the Gateway.
+
 When CatalogAPI or the Gateway provides a Request ID, remote-mode failures
 surface that correlation value without exposing credentials: startup failures
 include it in the stderr diagnostic, JSON-RPC errors include
@@ -367,7 +377,22 @@ Derived regional endpoints need no site field under `default`. Add
 `--mode remote --remote-url https://<REMOTE_MCP_HOST>/mcp` only to override the
 default entry.
 
-Remote mode rejects `--transport http` and `--transport streamable-http`.
+#### Remote mode, Streamable HTTP proxy
+
+```bash
+uv run alibabacloud-maxcompute-mcp-server \
+  --config /path/to/config.json \
+  --mode remote \
+  --transport streamable-http \
+  --host 127.0.0.1 \
+  --port 8000
+```
+
+The listener exposes `http://127.0.0.1:8000/mcp`. Keep the default loopback
+binding unless another trusted host must connect to this process. You can omit
+`--mode remote` under `default`; the process uses the same startup probe and
+falls back to the local Streamable HTTP implementation only if remote
+initialization fails.
 
 ### MCP tools
 
@@ -473,8 +498,9 @@ tokens, or bearer tokens in MCP client arguments.
 
 #### Streamable HTTP
 
-This listener is available only in local mode. Start the server (see above),
-then point your MCP client at `http://127.0.0.1:8000/mcp`.
+Start either local or remote Streamable HTTP as shown above, then point your MCP
+client at `http://127.0.0.1:8000/mcp`. Under `default`, the same local URL stays
+stable while startup selects the remote proxy or local SDK implementation.
 
 ### Development
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -7,7 +7,7 @@
 [![English](https://img.shields.io/badge/lang-English-blue)](README.md)
 [![中文](https://img.shields.io/badge/lang-中文-red)](README_ZH.md)
 
-阿里云 [MaxCompute](https://www.aliyun.com/product/odps) 的本地 [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) 启动器。它既可以用 `local` 模式运行原有 SDK 实现，也可以用 `remote` 模式作为托管版 MaxCompute MCP 服务的透明 stdio 代理。
+阿里云 [MaxCompute](https://www.aliyun.com/product/odps) 的本地 [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) 启动器。它既可以用 `local` 模式运行原有 SDK 实现，也可以用 `remote` 模式作为托管版 MaxCompute MCP 服务的透明 stdio 或 Streamable HTTP 代理。
 
 > [!IMPORTANT]
 > 推荐优先使用 MaxCompute Remote MCP Server。请先阅读托管版 Remote MCP
@@ -21,7 +21,7 @@
 ## 能力概览
 
 - **兼容原有配置**：通过已有 FE/Catalog endpoint 判断 Region 和 public/VPC 网络；简单 `region` + `network` 配置无需 Region 表即可生成 FE、Catalog 和 MCP endpoint。
-- **透明 remote 模式**：将 stdio MCP 消息原样转发到托管版 Streamable HTTP endpoint，不重建或重命名远端工具。
+- **透明 remote 模式**：将 stdio 和 Streamable HTTP MCP 消息转发到托管版 Streamable HTTP endpoint，不重建或重命名远端工具，并保留 MRTR、progress notification 和未来 MCP 字段。
 - **当前协议兼容**：使用 MCP Python SDK 2.x，保留现代 `2026-07-28` 请求的 metadata 与路由 Header，同时兼容 legacy initialize。
 - **标准 CatalogAPI 鉴权**：remote 代理使用现有凭证 Provider 对无 body 的 `mcpAccessToken` 请求签名，续期时重新取得当前 AK/STS/ECS RAM Role 凭证。
 - **凭证隔离**：只把短期 `mcpc_` bearer 发给 Gateway，不在 MCP 消息或 URL 中发送 AK Secret / STS 凭证；选定 remote 后失败也绝不 fallback 到本地 SDK。
@@ -55,15 +55,16 @@ MaxCompute Remote MCP Server。Remote MCP 服务减少本地运行环境和 MCP
 
 为保持老配置升级兼容，启动器默认使用 `default`。它从所选老配置的 FE 和 Catalog
 endpoint 判断 Region 和 public/VPC 网络，也支持显式 `region` + `network` 简单配置。
-本进程使用 stdio 且能够确定 Region/网络时，先通过 CatalogAPI 签发 token，再对唯一的
-地域 MCP endpoint 完成经过认证的 `initialize`；token 签发或 remote 初始化失败时
-fallback 到原有 local 实现。`--mode local` 可以显式固定原实现。
+能够确定 Region/网络时，本进程先通过 CatalogAPI 签发 token，再对唯一的地域 MCP
+endpoint 完成经过认证的 `initialize`。stdio 和 Streamable HTTP 使用相同的启动选型；
+token 签发或 remote 初始化失败时 fallback 到原有 local 实现。`--mode local` 可以
+显式固定原实现。
 
 | 模式 | MCP 路径 | 后端 | 本进程对外传输 |
 | --- | --- | --- | --- |
-| `default` | 启动时先探测 remote，再选择一种路径 | remote 优先；初始化失败使用本地 SDK | stdio；非 stdio 保持 local |
+| `default` | 启动时先探测 remote，再选择一种路径 | remote 优先；初始化失败使用本地 SDK | stdio 或 Streamable HTTP |
 | `local` | MCP Client → 本进程 → 本地 SDK | MaxCompute SDK / CatalogAPI | stdio 或 Streamable HTTP |
-| `remote` | MCP Client → 本进程 → 托管 Gateway | Remote MCP Streamable HTTP | 仅 stdio |
+| `remote` | MCP Client → 本进程 → 托管 Gateway | Remote MCP Streamable HTTP | stdio 或 Streamable HTTP |
 
 显式 `remote` 模式 fail closed：CatalogAPI 签发、MCP initialize、token 续期或
 Gateway 传输失败都会终止远端流程。`default` 只在选型前 fallback；一旦认证初始化
@@ -82,7 +83,7 @@ Gateway 传输失败都会终止远端流程。`default` 只在选型前 fallbac
 - remote 代理调用 CatalogAPI 的标准签名接口取得 300 秒 `mcpc_` token；不保存
   refresh token
 - lockfile 固定 MCP Python SDK 2.x，同时支持现代 `2026-07-28` 与协商后的 legacy
-  stdio client
+  client
 
 ### 安装
 
@@ -277,8 +278,8 @@ endpoint 选择公网 MCP，已识别的 VPC/内网 endpoint 选择 VPC MCP。�
 与已识别 endpoint 冲突则视为配置错误。
 
 VPC 配置绝不选择公网 MCP，也不跨 Region。只有自定义/历史 endpoint 且无法验证
-Region/网络、FE/Catalog 证据冲突，或进程使用本地 HTTP transport 时，`default` 保持
-原 local 实现；显式 `remote` 模式 fail closed。
+Region/网络或 FE/Catalog 证据冲突时，`default` 保持原 local 实现；显式 `remote`
+模式 fail closed。
 
 MCP 域名只按 Region 决定：中国内地 Region（`cn-*`，但不包括 `cn-hongkong`）使用
 `mcp`，`cn-hongkong` 和其他海外 Region 使用 `mcp-intl`。这不是账号站点探测；
@@ -306,6 +307,13 @@ CatalogAPI 签发 token 的链路不进入 RAM OAuth。生成的 endpoint 只在
 remote URL 必须是无 userinfo、query、fragment 且路径严格为 `/mcp` 的 resource。
 代理拒绝 redirect、忽略环境 HTTP proxy，并以 single-flight 方式通过 CatalogAPI
 续期短期 bearer token。CatalogAPI 接口无业务 body，scope 和 TTL 由服务端固定。
+
+Streamable HTTP 代理转发 `POST`、`GET` 和 `DELETE`，同时支持 JSON 和 Server-Sent
+Events（SSE）。代理保留请求 body 字节、非错误 remote 消息、session 与断点续传 Header、
+所有 `Mcp-*` 扩展 Header、MRTR state/input 字段、progress notification 以及未知的未来
+MCP 字段。stdio bridge 可能重新编码 JSON，但会保留 MCP 字段和值。代理不转发下游
+`Authorization` 和 `Cookie` Header，而是使用当前 CatalogAPI token，并在访问 Gateway
+前校验 `Host` 和 `Origin`。
 
 CatalogAPI 或 Gateway 返回 Request ID 时，remote 模式会在不暴露凭证的前提下保留该
 排查信息：启动失败会把 Request ID 写入 stderr；JSON-RPC 错误会写入
@@ -337,7 +345,20 @@ uv run alibabacloud-maxcompute-mcp-server --config /path/to/config.json
 按规则生成的地域 endpoint 在 `default` 下无需增加站点字段。仅在需要覆盖默认入口时增加
 `--mode remote --remote-url https://<REMOTE_MCP_HOST>/mcp`。
 
-remote 模式会拒绝 `--transport http` 和 `--transport streamable-http`。
+#### remote 模式，Streamable HTTP 代理
+
+```bash
+uv run alibabacloud-maxcompute-mcp-server \
+  --config /path/to/config.json \
+  --mode remote \
+  --transport streamable-http \
+  --host 127.0.0.1 \
+  --port 8000
+```
+
+listener 地址为 `http://127.0.0.1:8000/mcp`。除非其他可信主机必须访问本进程，否则请
+保留默认的 loopback 监听地址。`default` 下可以省略 `--mode remote`；启动探测成功时
+使用 remote 代理，remote 初始化失败时才 fallback 到 local Streamable HTTP 实现。
 
 ### MCP 工具
 
@@ -442,8 +463,9 @@ args 中。
 
 #### Streamable HTTP
 
-该 listener 仅在 local 模式可用。按上文启动后，将 MCP Client 地址指向
-`http://127.0.0.1:8000/mcp`。
+按上文启动 local 或 remote Streamable HTTP，再将 MCP Client 地址指向
+`http://127.0.0.1:8000/mcp`。`default` 下本地 URL 不变，由进程在启动时选择 remote
+代理或 local SDK 实现。
 
 ### 开发
 

--- a/maxcompute_catalog_mcp/remote_http_proxy.py
+++ b/maxcompute_catalog_mcp/remote_http_proxy.py
@@ -1,0 +1,390 @@
+"""Transparent local Streamable HTTP proxy for the remote MCP gateway."""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import AsyncIterator, Mapping
+from contextlib import asynccontextmanager
+from typing import Any
+
+import httpx2 as httpx
+from mcp.server.transport_security import (
+    TransportSecurityMiddleware,
+    TransportSecuritySettings,
+)
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response, StreamingResponse
+from starlette.routing import Route
+
+from .remote_proxy import (
+    AccessTokenProvider,
+    DynamicBearerAuth,
+    RemoteRequestIdTracker,
+)
+from .request_ids import request_id_from_exception, sanitize_request_id
+from .runtime_config import RemoteRuntimeConfig
+
+_MCP_PATH = "/mcp"
+_MCP_REQUEST_HEADERS = frozenset(
+    {
+        "accept",
+        "content-type",
+        "last-event-id",
+        "mcp-method",
+        "mcp-name",
+        "mcp-protocol-version",
+        "mcp-session-id",
+    }
+)
+_MCP_RESPONSE_HEADERS = frozenset(
+    {
+        "cache-control",
+        "content-type",
+        "last-event-id",
+        "mcp-protocol-version",
+        "mcp-session-id",
+        "retry-after",
+        "www-authenticate",
+        "x-acs-request-id",
+        "x-odps-request-id",
+        "x-request-id",
+    }
+)
+_REQUEST_ID_HEADER = "X-Request-ID"
+_REQUEST_ID_META_KEY = "com.aliyun.maxcompute/requestId"
+_REMOTE_REQUEST_ERROR_CODE = -32000
+_REMOTE_CONNECT_TIMEOUT_SECONDS = 30.0
+_LOGGER = logging.getLogger(__name__)
+
+
+def _forwarded_headers(
+    headers: Mapping[str, str],
+    allowed: frozenset[str],
+) -> dict[str, str]:
+    return {
+        name: value
+        for name, value in headers.items()
+        if name.lower() in allowed or name.lower().startswith("mcp-")
+    }
+
+
+def _transport_security(host: str, port: int) -> TransportSecurityMiddleware:
+    host_names = {host}
+    if host in {"127.0.0.1", "::1", "localhost"}:
+        host_names.update({"127.0.0.1", "::1", "localhost"})
+
+    allowed_hosts: list[str] = []
+    allowed_origins: list[str] = []
+    for host_name in sorted(host_names):
+        rendered_host = f"[{host_name}]" if ":" in host_name else host_name
+        allowed_hosts.extend(
+            [
+                rendered_host,
+                f"{rendered_host}:{port}",
+                f"{rendered_host}:*",
+            ]
+        )
+        allowed_origins.extend(
+            [
+                f"http://{rendered_host}:{port}",
+                f"http://{rendered_host}:*",
+            ]
+        )
+
+    return TransportSecurityMiddleware(
+        TransportSecuritySettings(
+            enable_dns_rebinding_protection=True,
+            allowed_hosts=allowed_hosts,
+            allowed_origins=allowed_origins,
+        )
+    )
+
+
+def _jsonrpc_id(body: bytes) -> int | str | None:
+    try:
+        payload = json.loads(body)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    request_id = payload.get("id")
+    if isinstance(request_id, bool) or not isinstance(request_id, int | str):
+        return None
+    return request_id
+
+
+def _add_request_id_to_error_data(error: dict[str, Any], request_id: str) -> None:
+    data = error.get("data")
+    if isinstance(data, dict):
+        if "request_id" not in data:
+            error["data"] = {**data, "request_id": request_id}
+        return
+    if data is None:
+        error["data"] = {"request_id": request_id}
+        return
+    error["data"] = {"details": data, "request_id": request_id}
+
+
+def _add_request_id_to_tool_error(result: dict[str, Any], request_id: str) -> None:
+    structured_content = result.get("structuredContent")
+    if (
+        isinstance(structured_content, dict)
+        and sanitize_request_id(structured_content.get("request_id")) is not None
+    ):
+        return
+    metadata = result.get("_meta")
+    if isinstance(metadata, dict):
+        if _REQUEST_ID_META_KEY not in metadata:
+            metadata[_REQUEST_ID_META_KEY] = request_id
+        return
+    result["_meta"] = {_REQUEST_ID_META_KEY: request_id}
+
+
+def _add_request_id_to_payload(payload: object, request_id: str) -> bool:
+    if not isinstance(payload, dict):
+        return False
+    error = payload.get("error")
+    if isinstance(error, dict):
+        _add_request_id_to_error_data(error, request_id)
+        return True
+    result = payload.get("result")
+    if isinstance(result, dict) and result.get("isError") is True:
+        _add_request_id_to_tool_error(result, request_id)
+        return True
+    return False
+
+
+def _enrich_json_body(body: bytes, request_id: str | None) -> bytes:
+    if request_id is None:
+        return body
+    try:
+        payload = json.loads(body)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return body
+    if not _add_request_id_to_payload(payload, request_id):
+        return body
+    return json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode()
+
+
+def _sse_data(line: bytes) -> bytes | None:
+    stripped = line.rstrip(b"\r\n")
+    if not stripped.startswith(b"data:"):
+        return None
+    value = stripped[len(b"data:") :]
+    if value.startswith(b" "):
+        value = value[1:]
+    return value
+
+
+def _enrich_sse_event(
+    lines: list[bytes],
+    terminator: bytes,
+    request_id: str | None,
+) -> bytes:
+    if request_id is None:
+        return b"".join(lines) + terminator
+    data_parts: list[bytes] = []
+    data_indices: list[int] = []
+    for index, line in enumerate(lines):
+        data = _sse_data(line)
+        if data is not None:
+            data_indices.append(index)
+            data_parts.append(data)
+    if not data_indices:
+        return b"".join(lines) + terminator
+    try:
+        payload = json.loads(b"\n".join(data_parts))
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return b"".join(lines) + terminator
+    if not _add_request_id_to_payload(payload, request_id):
+        return b"".join(lines) + terminator
+
+    encoded = json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode()
+    first_data_index = data_indices[0]
+    data_index_set = set(data_indices)
+    rewritten: list[bytes] = []
+    for index, line in enumerate(lines):
+        if index == first_data_index:
+            line_ending = b"\r\n" if line.endswith(b"\r\n") else b"\n"
+            rewritten.append(b"data: " + encoded + line_ending)
+        elif index not in data_index_set:
+            rewritten.append(line)
+    return b"".join(rewritten) + terminator
+
+
+async def _stream_sse_response(
+    response: httpx.Response,
+    request_id: str | None,
+) -> AsyncIterator[bytes]:
+    buffer = b""
+    event_lines: list[bytes] = []
+    try:
+        async for chunk in response.aiter_bytes():
+            buffer += chunk
+            while True:
+                newline_index = buffer.find(b"\n")
+                if newline_index < 0:
+                    break
+                line = buffer[: newline_index + 1]
+                buffer = buffer[newline_index + 1 :]
+                if line.rstrip(b"\r\n"):
+                    event_lines.append(line)
+                    continue
+                yield _enrich_sse_event(event_lines, line, request_id)
+                event_lines = []
+        if event_lines or buffer:
+            yield b"".join(event_lines) + buffer
+    finally:
+        await response.aclose()
+
+
+async def _stream_response(response: httpx.Response) -> AsyncIterator[bytes]:
+    try:
+        async for chunk in response.aiter_bytes():
+            yield chunk
+    finally:
+        await response.aclose()
+
+
+def _remote_error_response(body: bytes, error: Exception) -> JSONResponse:
+    request_id = request_id_from_exception(error)
+    if request_id is None:
+        _LOGGER.warning(
+            "Remote MCP request failed (%s)",
+            type(error).__name__,
+        )
+    else:
+        _LOGGER.warning(
+            "Remote MCP request failed (%s, request_id=%s)",
+            type(error).__name__,
+            request_id,
+        )
+    error_payload: dict[str, Any] = {
+        "code": _REMOTE_REQUEST_ERROR_CODE,
+        "message": "remote MCP request failed",
+    }
+    if request_id is not None:
+        error_payload["data"] = {"request_id": request_id}
+    return JSONResponse(
+        {
+            "jsonrpc": "2.0",
+            "id": _jsonrpc_id(body),
+            "error": error_payload,
+        },
+        status_code=502,
+    )
+
+
+async def _proxy_response(response: httpx.Response) -> Response:
+    headers = _forwarded_headers(response.headers, _MCP_RESPONSE_HEADERS)
+    content_type = response.headers.get("content-type", "").lower()
+    request_id = sanitize_request_id(response.headers.get(_REQUEST_ID_HEADER))
+    if content_type.startswith("application/json"):
+        try:
+            body = await response.aread()
+        finally:
+            await response.aclose()
+        return Response(
+            _enrich_json_body(body, request_id),
+            status_code=response.status_code,
+            headers=headers,
+        )
+    if response.status_code in {204, 304}:
+        await response.aclose()
+        return Response(status_code=response.status_code, headers=headers)
+    if content_type.startswith("text/event-stream"):
+        return StreamingResponse(
+            _stream_sse_response(response, request_id),
+            status_code=response.status_code,
+            headers=headers,
+        )
+    return StreamingResponse(
+        _stream_response(response),
+        status_code=response.status_code,
+        headers=headers,
+    )
+
+
+def build_remote_http_proxy_app(
+    config: RemoteRuntimeConfig,
+    token_provider: AccessTokenProvider,
+    *,
+    host: str,
+    port: int,
+) -> Starlette:
+    """Build a hardened ASGI reverse proxy for one fixed Remote MCP endpoint."""
+
+    request_ids = RemoteRequestIdTracker()
+    security = _transport_security(host, port)
+
+    @asynccontextmanager
+    async def lifespan(app: Starlette) -> AsyncIterator[None]:
+        timeout = httpx.Timeout(_REMOTE_CONNECT_TIMEOUT_SECONDS, read=None)
+        async with httpx.AsyncClient(
+            auth=DynamicBearerAuth(token_provider),
+            event_hooks={"response": [request_ids.observe_response]},
+            follow_redirects=False,
+            timeout=timeout,
+            trust_env=False,
+        ) as client:
+            app.state.remote_mcp_client = client
+            yield
+
+    async def proxy(request: Request) -> Response:
+        validation_error = await security.validate_request(
+            request,
+            is_post=request.method == "POST",
+        )
+        if validation_error is not None:
+            return validation_error
+        body = await request.body()
+        try:
+            upstream_request = request.app.state.remote_mcp_client.build_request(
+                request.method,
+                config.url,
+                content=body,
+                headers=_forwarded_headers(request.headers, _MCP_REQUEST_HEADERS),
+            )
+            upstream_response = await request.app.state.remote_mcp_client.send(
+                upstream_request,
+                stream=True,
+                follow_redirects=False,
+            )
+        except Exception as error:  # noqa: BLE001 -- sanitize the network boundary.
+            return _remote_error_response(body, error)
+        return await _proxy_response(upstream_response)
+
+    return Starlette(
+        routes=[Route(_MCP_PATH, proxy, methods=["DELETE", "GET", "POST"])],
+        lifespan=lifespan,
+    )
+
+
+def run_remote_http_proxy(
+    config: RemoteRuntimeConfig,
+    token_provider: AccessTokenProvider,
+    *,
+    host: str,
+    port: int,
+) -> None:
+    """Serve the Remote MCP reverse proxy until process shutdown."""
+
+    import uvicorn
+
+    app = build_remote_http_proxy_app(
+        config,
+        token_provider,
+        host=host,
+        port=port,
+    )
+    uvicorn.run(app, host=host, port=port)

--- a/maxcompute_catalog_mcp/runtime_config.py
+++ b/maxcompute_catalog_mcp/runtime_config.py
@@ -298,10 +298,10 @@ def load_runtime_config(
     )
     if requested_mode is RuntimeMode.LOCAL:
         return RuntimeConfig(mode=RuntimeMode.LOCAL, profile=resolved_profile)
-    if not allow_remote:
-        if requested_mode is RuntimeMode.REMOTE:
-            raise ValueError("remote proxy mode is only available with stdio")
-        return RuntimeConfig(mode=requested_mode, profile=resolved_profile)
+    # ``allow_remote`` remains accepted for callers of older releases, but
+    # transport selection no longer changes runtime-mode semantics. Remote and
+    # default modes support both stdio and Streamable HTTP.
+    _ = allow_remote
 
     if (
         requested_mode is RuntimeMode.DEFAULT

--- a/maxcompute_catalog_mcp/server.py
+++ b/maxcompute_catalog_mcp/server.py
@@ -347,6 +347,59 @@ async def _run_forced_remote_stdio(
     await _run_remote_proxy(config, token_provider)
 
 
+def _run_remote_http(
+    config: RemoteRuntimeConfig,
+    token_provider: CatalogAccessTokenProvider,
+    *,
+    host: str,
+    port: int,
+) -> None:
+    """Run the transparent Streamable HTTP-to-Streamable HTTP proxy."""
+
+    from .remote_http_proxy import run_remote_http_proxy
+
+    run_remote_http_proxy(
+        config,
+        token_provider,
+        host=host,
+        port=port,
+    )
+
+
+def _run_forced_remote_http(
+    config: RemoteRuntimeConfig,
+    token_provider: CatalogAccessTokenProvider,
+    *,
+    host: str,
+    port: int,
+) -> None:
+    """Initialize and run Remote HTTP mode without a Local fallback."""
+
+    asyncio.run(_initialize_remote_mcp(config, token_provider))
+    _run_remote_http(
+        config,
+        token_provider,
+        host=host,
+        port=port,
+    )
+
+
+def _log_remote_fallback(error: Exception) -> None:
+    request_id = request_id_from_exception(error)
+    if request_id is None:
+        _LOGGER.warning(
+            "Remote MCP initialization failed; falling back to local mode (%s)",
+            type(error).__name__,
+        )
+    else:
+        _LOGGER.warning(
+            "Remote MCP initialization failed; falling back to local mode "
+            "(%s, request_id=%s)",
+            type(error).__name__,
+            request_id,
+        )
+
+
 async def _run_default_stdio(
     runtime_config: RuntimeConfig,
     config_path: str | None,
@@ -362,25 +415,45 @@ async def _run_default_stdio(
             )
             await _initialize_remote_mcp(remote, token_provider)
         except Exception as error:  # noqa: BLE001 -- default mode must fall back.
-            request_id = request_id_from_exception(error)
-            if request_id is None:
-                _LOGGER.warning(
-                    "Remote MCP initialization failed; falling back to local mode (%s)",
-                    type(error).__name__,
-                )
-            else:
-                _LOGGER.warning(
-                    "Remote MCP initialization failed; falling back to local mode "
-                    "(%s, request_id=%s)",
-                    type(error).__name__,
-                    request_id,
-                )
+            _log_remote_fallback(error)
         else:
             await _run_remote_proxy(remote, token_provider)
             return
 
     tools = build_tools(config_path, profile=runtime_config.profile)
     await _run_stdio(tools)
+
+
+def _run_default_http(
+    runtime_config: RuntimeConfig,
+    config_path: str | None,
+    *,
+    host: str,
+    port: int,
+) -> None:
+    """Select Remote HTTP once at startup, otherwise serve the Local MCP."""
+
+    remote = runtime_config.remote
+    if remote is not None:
+        try:
+            token_provider = build_remote_token_provider(
+                config_path,
+                runtime_config.profile,
+            )
+            asyncio.run(_initialize_remote_mcp(remote, token_provider))
+        except Exception as error:  # noqa: BLE001 -- default mode must fall back.
+            _log_remote_fallback(error)
+        else:
+            _run_remote_http(
+                remote,
+                token_provider,
+                host=host,
+                port=port,
+            )
+            return
+
+    tools = build_tools(config_path, profile=runtime_config.profile)
+    _run_http(tools, host=host, port=port)
 
 
 def _run_http(tools: Tools, host: str, port: int) -> None:
@@ -426,14 +499,11 @@ def main() -> None:
             mode=options.mode,
             remote_url=options.remote_url,
             profile=options.profile,
-            allow_remote=options.transport == "stdio",
         )
     except (TypeError, ValueError) as error:
         sys.exit(f"Invalid MCP runtime config: {error}")
 
     if runtime_config.mode is RuntimeMode.REMOTE:
-        if options.transport != "stdio":
-            sys.exit("Remote MCP proxy mode supports only stdio transport")
         if runtime_config.remote is None:
             sys.exit("Remote MCP proxy configuration is missing")
         try:
@@ -444,18 +514,34 @@ def main() -> None:
         except RuntimeError:
             sys.exit("Remote MCP token provider initialization failed")
         try:
-            asyncio.run(
-                _run_forced_remote_stdio(
+            if options.transport in ("http", "streamable-http"):
+                _run_forced_remote_http(
                     runtime_config.remote,
                     token_provider,
+                    host=options.host,
+                    port=options.port,
                 )
-            )
+            else:
+                asyncio.run(
+                    _run_forced_remote_stdio(
+                        runtime_config.remote,
+                        token_provider,
+                    )
+                )
         except RemoteInitializationError as error:
             sys.exit(str(error))
         return
 
     if runtime_config.mode is RuntimeMode.DEFAULT and runtime_config.remote is not None:
-        asyncio.run(_run_default_stdio(runtime_config, options.config_path))
+        if options.transport in ("http", "streamable-http"):
+            _run_default_http(
+                runtime_config,
+                options.config_path,
+                host=options.host,
+                port=options.port,
+            )
+        else:
+            asyncio.run(_run_default_stdio(runtime_config, options.config_path))
         return
 
     tools = build_tools(options.config_path, profile=runtime_config.profile)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
   "maxcompute_tea_util>=0.0.1",
   "mcp>=2.0.0,<3",     # Official MCP Python SDK with 2026-07-28 support
   "httpx2>=2.12.0,<3", # MCP 2.x Streamable HTTP client dependency
+  "starlette>=1.6.0,<2", # ASGI surface for the transparent HTTP proxy
   "uvicorn>=0.52.4",   # ASGI server for Streamable HTTP mode
   # Security floors for runtime transitive dependencies. These must be public
   # Requires-Dist entries because PyPI installers do not read [tool.uv].

--- a/tests/test_remote_http_proxy.py
+++ b/tests/test_remote_http_proxy.py
@@ -1,0 +1,958 @@
+"""Streamable HTTP integration tests for the transparent Remote proxy."""
+
+from __future__ import annotations
+
+import asyncio
+import gzip
+import json
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import patch
+
+import httpx2 as httpx
+import pytest
+from starlette.testclient import TestClient
+
+from maxcompute_catalog_mcp.remote_auth import CatalogTokenRequestError
+from maxcompute_catalog_mcp.remote_http_proxy import (
+    build_remote_http_proxy_app,
+    run_remote_http_proxy,
+)
+from maxcompute_catalog_mcp.remote_proxy import DynamicBearerAuth
+from maxcompute_catalog_mcp.runtime_config import RemoteRuntimeConfig
+
+REMOTE_URL = "https://gateway.example.com/mcp"
+LOCAL_BASE_URL = "http://127.0.0.1:8123"
+PROTOCOL_VERSION = "2025-06-18"
+REAL_ASYNC_CLIENT = httpx.AsyncClient
+
+
+@dataclass
+class RotatingTokenProvider:
+    calls: int = 0
+
+    async def get_access_token(self) -> str:
+        self.calls += 1
+        return f"catalog-token-{self.calls}"
+
+
+class FailingTokenProvider:
+    async def get_access_token(self) -> str:
+        raise CatalogTokenRequestError("catalog-token-request-403")
+
+
+class StaticAsyncStream(httpx.AsyncByteStream):
+    def __init__(self, *chunks: bytes) -> None:
+        self._chunks = chunks
+
+    async def __aiter__(self):
+        for chunk in self._chunks:
+            yield chunk
+
+
+class TrackingAsyncStream(StaticAsyncStream):
+    def __init__(self, *chunks: bytes) -> None:
+        super().__init__(*chunks)
+        self.closed = False
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+RequestHandler = Callable[[httpx.Request], Awaitable[httpx.Response]]
+
+
+def _patched_client_factory(
+    handler: RequestHandler,
+    observed_options: list[dict[str, Any]] | None = None,
+) -> Callable[..., httpx.AsyncClient]:
+    def factory(**kwargs: Any) -> httpx.AsyncClient:
+        if observed_options is not None:
+            observed_options.append(kwargs.copy())
+        return REAL_ASYNC_CLIENT(
+            transport=httpx.MockTransport(handler),
+            **kwargs,
+        )
+
+    return factory
+
+
+def _app(provider: Any = None):
+    return build_remote_http_proxy_app(
+        RemoteRuntimeConfig(url=REMOTE_URL),
+        provider or RotatingTokenProvider(),
+        host="127.0.0.1",
+        port=8123,
+    )
+
+
+def test_post_json_is_transparently_proxied_with_dynamic_catalog_auth() -> None:
+    """POST preserves MCP semantics but replaces caller-supplied authorization."""
+    provider = RotatingTokenProvider()
+    observed_options: list[dict[str, Any]] = []
+    requests: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        await request.aread()
+        requests.append(request)
+        return httpx.Response(
+            200,
+            headers={
+                "content-type": "application/json",
+                "mcp-session-id": "remote-session-1",
+                "x-request-id": "gateway-post-1",
+            },
+            json={"jsonrpc": "2.0", "id": 1, "result": {"tools": []}},
+        )
+
+    with (
+        patch(
+            "maxcompute_catalog_mcp.remote_http_proxy.httpx.AsyncClient",
+            side_effect=_patched_client_factory(handler, observed_options),
+        ),
+        TestClient(_app(provider), base_url=LOCAL_BASE_URL) as client,
+    ):
+        response = client.post(
+            "/mcp?untrusted=query",
+            headers={
+                "Accept": "application/json, text/event-stream",
+                "Authorization": "Bearer caller-controlled-token",
+                "Content-Type": "application/json",
+                "MCP-Protocol-Version": PROTOCOL_VERSION,
+                "Mcp-Method": "tools/list",
+                "Mcp-Future-Extension": "preserve-me",
+                "Origin": LOCAL_BASE_URL,
+            },
+            json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"jsonrpc": "2.0", "id": 1, "result": {"tools": []}}
+    assert response.headers["mcp-session-id"] == "remote-session-1"
+    assert response.headers["x-request-id"] == "gateway-post-1"
+    assert len(requests) == 1
+    upstream = requests[0]
+    assert str(upstream.url) == REMOTE_URL
+    assert upstream.headers["authorization"] == "Bearer catalog-token-1"
+    assert upstream.headers["accept"] == "application/json, text/event-stream"
+    assert upstream.headers["content-type"].startswith("application/json")
+    assert upstream.headers["mcp-protocol-version"] == PROTOCOL_VERSION
+    assert upstream.headers["mcp-method"] == "tools/list"
+    assert upstream.headers["mcp-future-extension"] == "preserve-me"
+    assert "origin" not in upstream.headers
+    assert provider.calls == 1
+
+    assert len(observed_options) == 1
+    options = observed_options[0]
+    assert isinstance(options["auth"], DynamicBearerAuth)
+    assert options["auth"]._provider is provider
+    assert options["follow_redirects"] is False
+    assert options["trust_env"] is False
+
+
+def test_get_sse_preserves_session_resumption_and_streaming_headers() -> None:
+    """GET keeps the downstream session and Last-Event-ID isolated end to end."""
+    provider = RotatingTokenProvider()
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "GET"
+        assert request.headers["authorization"] == "Bearer catalog-token-1"
+        assert request.headers["mcp-session-id"] == "remote-session-get"
+        assert request.headers["last-event-id"] == "event-41"
+        assert request.headers["mcp-protocol-version"] == PROTOCOL_VERSION
+        return httpx.Response(
+            200,
+            headers={
+                "content-type": "text/event-stream",
+                "cache-control": "no-cache",
+                "mcp-session-id": "remote-session-get",
+            },
+            stream=StaticAsyncStream(
+                b"id: event-42\n"
+                b"event: message\n"
+                b'data: {"jsonrpc":"2.0","method":"notifications/progress"}\n\n'
+            ),
+        )
+
+    with (
+        patch(
+            "maxcompute_catalog_mcp.remote_http_proxy.httpx.AsyncClient",
+            side_effect=_patched_client_factory(handler),
+        ),
+        TestClient(_app(provider), base_url=LOCAL_BASE_URL) as client,
+    ):
+        response = client.get(
+            "/mcp",
+            headers={
+                "Accept": "text/event-stream",
+                "Authorization": "Bearer caller-controlled-token",
+                "MCP-Protocol-Version": PROTOCOL_VERSION,
+                "Mcp-Session-Id": "remote-session-get",
+                "Last-Event-ID": "event-41",
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/event-stream")
+    assert response.headers["cache-control"] == "no-cache"
+    assert response.headers["mcp-session-id"] == "remote-session-get"
+    assert "id: event-42" in response.text
+    assert "notifications/progress" in response.text
+
+
+def test_delete_is_forwarded_without_sharing_session_state() -> None:
+    """DELETE terminates exactly the session supplied by the downstream client."""
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "DELETE"
+        assert request.headers["mcp-session-id"] == "remote-session-delete"
+        assert request.headers["authorization"] == "Bearer catalog-token-1"
+        return httpx.Response(204)
+
+    with (
+        patch(
+            "maxcompute_catalog_mcp.remote_http_proxy.httpx.AsyncClient",
+            side_effect=_patched_client_factory(handler),
+        ),
+        TestClient(_app(), base_url=LOCAL_BASE_URL) as client,
+    ):
+        response = client.delete(
+            "/mcp",
+            headers={
+                "Mcp-Session-Id": "remote-session-delete",
+                "MCP-Protocol-Version": PROTOCOL_VERSION,
+            },
+        )
+
+    assert response.status_code == 204
+    assert response.content == b""
+
+
+def test_post_sse_keeps_streamable_http_response_semantics() -> None:
+    """A POST may return SSE and must not be collapsed into a JSON response."""
+
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            stream=StaticAsyncStream(
+                b"event: message\n"
+                b'data: {"jsonrpc":"2.0","id":8,"result":{"ok":true}}\n\n'
+            ),
+        )
+
+    with (
+        patch(
+            "maxcompute_catalog_mcp.remote_http_proxy.httpx.AsyncClient",
+            side_effect=_patched_client_factory(handler),
+        ),
+        TestClient(_app(), base_url=LOCAL_BASE_URL) as client,
+    ):
+        response = client.post(
+            "/mcp",
+            headers={
+                "Accept": "application/json, text/event-stream",
+                "Content-Type": "application/json",
+            },
+            json={"jsonrpc": "2.0", "id": 8, "method": "tools/list"},
+        )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/event-stream")
+    assert '"id":8' in response.text
+    assert '"ok":true' in response.text
+
+
+def test_invalid_origin_and_host_are_rejected_before_upstream_auth() -> None:
+    """The local listener enforces the MCP DNS-rebinding boundary."""
+    provider = RotatingTokenProvider()
+    upstream_calls = 0
+
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        nonlocal upstream_calls
+        upstream_calls += 1
+        return httpx.Response(202, stream=StaticAsyncStream())
+
+    with (
+        patch(
+            "maxcompute_catalog_mcp.remote_http_proxy.httpx.AsyncClient",
+            side_effect=_patched_client_factory(handler),
+        ),
+        TestClient(_app(provider), base_url=LOCAL_BASE_URL) as client,
+    ):
+        bad_origin = client.post(
+            "/mcp",
+            headers={
+                "Content-Type": "application/json",
+                "Origin": "https://attacker.example.com",
+            },
+            json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+        )
+        bad_host = client.post(
+            "/mcp",
+            headers={
+                "Content-Type": "application/json",
+                "Host": "attacker.example.com",
+            },
+            json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+        )
+
+    assert bad_origin.status_code == 403
+    assert bad_host.status_code == 421
+    assert upstream_calls == 0
+    assert provider.calls == 0
+
+
+def test_concurrent_clients_keep_their_remote_sessions_isolated() -> None:
+    """The proxy carries session state per request instead of process globally."""
+    provider = RotatingTokenProvider()
+    seen_sessions: list[str] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        session_id = request.headers["mcp-session-id"]
+        seen_sessions.append(session_id)
+        await asyncio.sleep(0)
+        return httpx.Response(
+            200,
+            headers={"content-type": "application/json"},
+            json={"jsonrpc": "2.0", "id": session_id, "result": {}},
+        )
+
+    async def scenario() -> None:
+        with patch(
+            "maxcompute_catalog_mcp.remote_http_proxy.httpx.AsyncClient",
+            side_effect=_patched_client_factory(handler),
+        ):
+            app = _app(provider)
+            async with (
+                app.router.lifespan_context(app),
+                REAL_ASYNC_CLIENT(
+                    transport=httpx.ASGITransport(app=app),
+                    base_url=LOCAL_BASE_URL,
+                ) as client,
+            ):
+                responses = await asyncio.gather(
+                    client.post(
+                        "/mcp",
+                        headers={
+                            "Content-Type": "application/json",
+                            "Mcp-Session-Id": "session-a",
+                        },
+                        json={"jsonrpc": "2.0", "id": "session-a", "method": "ping"},
+                    ),
+                    client.post(
+                        "/mcp",
+                        headers={
+                            "Content-Type": "application/json",
+                            "Mcp-Session-Id": "session-b",
+                        },
+                        json={"jsonrpc": "2.0", "id": "session-b", "method": "ping"},
+                    ),
+                )
+
+        assert {response.json()["id"] for response in responses} == {
+            "session-a",
+            "session-b",
+        }
+
+    asyncio.run(scenario())
+
+    assert set(seen_sessions) == {"session-a", "session-b"}
+    assert provider.calls == 2
+
+
+def test_jsonrpc_error_body_gains_gateway_request_id() -> None:
+    """A gateway request ID is carried in both the HTTP header and MCP error body."""
+
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            400,
+            headers={
+                "content-type": "application/json",
+                "x-request-id": "gateway-jsonrpc-400",
+            },
+            json={
+                "jsonrpc": "2.0",
+                "id": 11,
+                "error": {"code": -32600, "message": "invalid request"},
+            },
+        )
+
+    with (
+        patch(
+            "maxcompute_catalog_mcp.remote_http_proxy.httpx.AsyncClient",
+            side_effect=_patched_client_factory(handler),
+        ),
+        TestClient(_app(), base_url=LOCAL_BASE_URL) as client,
+    ):
+        response = client.post(
+            "/mcp",
+            headers={"Content-Type": "application/json"},
+            json={"jsonrpc": "2.0", "id": 11, "method": "tools/call"},
+        )
+
+    assert response.status_code == 400
+    assert response.headers["x-request-id"] == "gateway-jsonrpc-400"
+    assert response.json()["error"]["data"] == {"request_id": "gateway-jsonrpc-400"}
+
+
+def test_sse_error_event_gains_gateway_request_id() -> None:
+    """Request ID enrichment also works when the MCP response uses SSE."""
+
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={
+                "content-type": "text/event-stream",
+                "x-request-id": "gateway-sse-error",
+            },
+            stream=StaticAsyncStream(
+                b"event: message\n"
+                b'data: {"jsonrpc":"2.0","id":12,"error":'
+                b'{"code":-32603,"message":"failed"}}\n\n'
+            ),
+        )
+
+    with (
+        patch(
+            "maxcompute_catalog_mcp.remote_http_proxy.httpx.AsyncClient",
+            side_effect=_patched_client_factory(handler),
+        ),
+        TestClient(_app(), base_url=LOCAL_BASE_URL) as client,
+    ):
+        response = client.post(
+            "/mcp",
+            headers={
+                "Accept": "application/json, text/event-stream",
+                "Content-Type": "application/json",
+            },
+            json={"jsonrpc": "2.0", "id": 12, "method": "tools/call"},
+        )
+
+    data_line = next(
+        line.removeprefix("data: ")
+        for line in response.text.splitlines()
+        if line.startswith("data: ")
+    )
+    payload = json.loads(data_line)
+    assert payload["error"]["data"] == {"request_id": "gateway-sse-error"}
+
+
+def test_catalog_token_failure_returns_safe_request_id_error_body() -> None:
+    """Token refresh failures are fail-closed and expose only safe correlation data."""
+
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        raise AssertionError("upstream must not run without a Catalog token")
+
+    with (
+        patch(
+            "maxcompute_catalog_mcp.remote_http_proxy.httpx.AsyncClient",
+            side_effect=_patched_client_factory(handler),
+        ),
+        TestClient(_app(FailingTokenProvider()), base_url=LOCAL_BASE_URL) as client,
+    ):
+        response = client.post(
+            "/mcp",
+            headers={"Content-Type": "application/json"},
+            json={"jsonrpc": "2.0", "id": 13, "method": "tools/list"},
+        )
+
+    assert response.status_code == 502
+    assert response.json() == {
+        "jsonrpc": "2.0",
+        "id": 13,
+        "error": {
+            "code": -32000,
+            "message": "remote MCP request failed",
+            "data": {"request_id": "catalog-token-request-403"},
+        },
+    }
+    assert "Bearer" not in response.text
+
+
+@pytest.mark.parametrize(
+    ("upstream_payload", "expected_payload"),
+    [
+        (
+            {
+                "jsonrpc": "2.0",
+                "id": 21,
+                "error": {
+                    "code": -32001,
+                    "message": "denied",
+                    "data": {"reason": "policy"},
+                },
+            },
+            {
+                "jsonrpc": "2.0",
+                "id": 21,
+                "error": {
+                    "code": -32001,
+                    "message": "denied",
+                    "data": {
+                        "reason": "policy",
+                        "request_id": "gateway-payload-21",
+                    },
+                },
+            },
+        ),
+        (
+            {
+                "jsonrpc": "2.0",
+                "id": 21,
+                "error": {
+                    "code": -32001,
+                    "message": "denied",
+                    "data": {"request_id": "backend-request-id"},
+                },
+            },
+            {
+                "jsonrpc": "2.0",
+                "id": 21,
+                "error": {
+                    "code": -32001,
+                    "message": "denied",
+                    "data": {"request_id": "backend-request-id"},
+                },
+            },
+        ),
+        (
+            {
+                "jsonrpc": "2.0",
+                "id": 21,
+                "error": {
+                    "code": -32001,
+                    "message": "denied",
+                    "data": "provider detail",
+                },
+            },
+            {
+                "jsonrpc": "2.0",
+                "id": 21,
+                "error": {
+                    "code": -32001,
+                    "message": "denied",
+                    "data": {
+                        "details": "provider detail",
+                        "request_id": "gateway-payload-21",
+                    },
+                },
+            },
+        ),
+        (
+            {
+                "jsonrpc": "2.0",
+                "id": 21,
+                "result": {
+                    "content": [{"type": "text", "text": "failed"}],
+                    "structuredContent": {"request_id": "backend-tool-request"},
+                    "isError": True,
+                },
+            },
+            {
+                "jsonrpc": "2.0",
+                "id": 21,
+                "result": {
+                    "content": [{"type": "text", "text": "failed"}],
+                    "structuredContent": {"request_id": "backend-tool-request"},
+                    "isError": True,
+                },
+            },
+        ),
+        (
+            {
+                "jsonrpc": "2.0",
+                "id": 21,
+                "result": {
+                    "_meta": {"existing": "metadata"},
+                    "content": [{"type": "text", "text": "failed"}],
+                    "isError": True,
+                },
+            },
+            {
+                "jsonrpc": "2.0",
+                "id": 21,
+                "result": {
+                    "_meta": {
+                        "existing": "metadata",
+                        "com.aliyun.maxcompute/requestId": "gateway-payload-21",
+                    },
+                    "content": [{"type": "text", "text": "failed"}],
+                    "isError": True,
+                },
+            },
+        ),
+        (
+            {
+                "jsonrpc": "2.0",
+                "id": 21,
+                "result": {
+                    "content": [{"type": "text", "text": "failed"}],
+                    "isError": True,
+                },
+            },
+            {
+                "jsonrpc": "2.0",
+                "id": 21,
+                "result": {
+                    "_meta": {"com.aliyun.maxcompute/requestId": "gateway-payload-21"},
+                    "content": [{"type": "text", "text": "failed"}],
+                    "isError": True,
+                },
+            },
+        ),
+    ],
+)
+def test_json_failures_preserve_details_and_existing_request_ids(
+    upstream_payload: dict[str, Any],
+    expected_payload: dict[str, Any],
+) -> None:
+    """Correlation enrichment never discards provider details or body IDs."""
+
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={
+                "content-type": "application/json",
+                "x-request-id": "gateway-payload-21",
+            },
+            json=upstream_payload,
+        )
+
+    with (
+        patch(
+            "maxcompute_catalog_mcp.remote_http_proxy.httpx.AsyncClient",
+            side_effect=_patched_client_factory(handler),
+        ),
+        TestClient(_app(), base_url=LOCAL_BASE_URL) as client,
+    ):
+        response = client.post(
+            "/mcp",
+            headers={"Content-Type": "application/json"},
+            json={"jsonrpc": "2.0", "id": 21, "method": "tools/call"},
+        )
+
+    assert response.json() == expected_payload
+
+
+@pytest.mark.parametrize(
+    "upstream_body",
+    [
+        b"not-json",
+        b"[]",
+        b'{"jsonrpc":"2.0","id":22,"result":{"ok":true}}',
+    ],
+)
+def test_non_error_json_bodies_remain_byte_for_byte_unchanged(
+    upstream_body: bytes,
+) -> None:
+    """A response header alone does not mutate malformed or successful payloads."""
+
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={
+                "content-type": "application/json",
+                "x-request-id": "gateway-non-error-22",
+            },
+            content=upstream_body,
+        )
+
+    with (
+        patch(
+            "maxcompute_catalog_mcp.remote_http_proxy.httpx.AsyncClient",
+            side_effect=_patched_client_factory(handler),
+        ),
+        TestClient(_app(), base_url=LOCAL_BASE_URL) as client,
+    ):
+        response = client.post(
+            "/mcp",
+            headers={"Content-Type": "application/json"},
+            json={"jsonrpc": "2.0", "id": 22, "method": "tools/list"},
+        )
+
+    assert response.content == upstream_body
+
+
+def test_sse_parser_preserves_heartbeats_and_enriches_chunked_crlf_error() -> None:
+    """SSE framing survives chunk boundaries, CRLF, comments, and partial tails."""
+
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={
+                "content-type": "text/event-stream",
+                "x-request-id": "gateway-chunked-sse",
+            },
+            stream=StaticAsyncStream(
+                b": heartbeat\r\n\r\nevent: message\r\ndata:not-json\r\n\r\n",
+                b'event: message\r\ndata: {"jsonrpc":"2.0",',
+                b'\r\ndata: "id":23,"error":{"code":-32603,',
+                b'"message":"failed"}}\r\n\r\n: trailing',
+            ),
+        )
+
+    with (
+        patch(
+            "maxcompute_catalog_mcp.remote_http_proxy.httpx.AsyncClient",
+            side_effect=_patched_client_factory(handler),
+        ),
+        TestClient(_app(), base_url=LOCAL_BASE_URL) as client,
+    ):
+        response = client.post(
+            "/mcp",
+            headers={"Content-Type": "application/json"},
+            json={"jsonrpc": "2.0", "id": 23, "method": "tools/call"},
+        )
+
+    assert ": heartbeat\r\n\r\n" in response.text
+    assert "data:not-json\r\n\r\n" in response.text
+    assert ": trailing" in response.text
+    enriched_line = next(
+        line.removeprefix("data: ")
+        for line in response.text.splitlines()
+        if '"id":23' in line
+    )
+    assert json.loads(enriched_line)["error"]["data"] == {
+        "request_id": "gateway-chunked-sse"
+    }
+
+
+def test_non_mcp_response_body_streams_and_closes_upstream() -> None:
+    """Unexpected bodies remain transparent and release the upstream stream."""
+    upstream_stream = TrackingAsyncStream(b"first-", b"second")
+
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            418,
+            headers={"content-type": "application/octet-stream"},
+            stream=upstream_stream,
+        )
+
+    with (
+        patch(
+            "maxcompute_catalog_mcp.remote_http_proxy.httpx.AsyncClient",
+            side_effect=_patched_client_factory(handler),
+        ),
+        TestClient(_app(), base_url=LOCAL_BASE_URL) as client,
+    ):
+        response = client.get("/mcp")
+
+    assert response.status_code == 418
+    assert response.content == b"first-second"
+    assert upstream_stream.closed is True
+
+
+def test_compressed_sse_is_decoded_before_protocol_processing() -> None:
+    """Gateway compression cannot hide SSE framing from request-ID enrichment."""
+    compressed = gzip.compress(
+        b"event: message\n"
+        b'data: {"jsonrpc":"2.0","id":24,"error":'
+        b'{"code":-32603,"message":"failed"}}\n\n'
+    )
+
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={
+                "content-encoding": "gzip",
+                "content-type": "text/event-stream",
+                "x-request-id": "gateway-compressed-sse",
+            },
+            stream=StaticAsyncStream(compressed),
+        )
+
+    with (
+        patch(
+            "maxcompute_catalog_mcp.remote_http_proxy.httpx.AsyncClient",
+            side_effect=_patched_client_factory(handler),
+        ),
+        TestClient(_app(), base_url=LOCAL_BASE_URL) as client,
+    ):
+        response = client.post(
+            "/mcp",
+            headers={"Content-Type": "application/json"},
+            json={"jsonrpc": "2.0", "id": 24, "method": "tools/call"},
+        )
+
+    assert "content-encoding" not in response.headers
+    data_line = next(
+        line.removeprefix("data: ")
+        for line in response.text.splitlines()
+        if line.startswith("data: ")
+    )
+    assert json.loads(data_line)["error"]["data"] == {
+        "request_id": "gateway-compressed-sse"
+    }
+
+
+def test_mrtr_request_and_sse_messages_are_preserved_byte_for_byte() -> None:
+    """MRTR state, input, progress, and input-required results remain opaque."""
+    request_body = (
+        b'{ "jsonrpc": "2.0", "id": 31, "method": "tools/call", '
+        b'"params": { "name": "maxcompute_generate_sql", '
+        b'"arguments": {"question":"revenue?"}, '
+        b'"requestState": "opaque.sealed.state", '
+        b'"inputResponses": {"business_clarifications": '
+        b'{"action":"accept","content":{"time_semantics":"calendar month"}}}, '
+        b'"_meta": {"progressToken":"mrtr-round-2", '
+        b'"io.modelcontextprotocol/protocolVersion":"2026-07-28", '
+        b'"io.modelcontextprotocol/clientCapabilities":'
+        b'{"elicitation":{"form":{}}}} } }'
+    )
+    response_body = (
+        b"event: message\n"
+        b'data: {"jsonrpc":"2.0","method":"notifications/progress",'
+        b'"params":{"progressToken":"mrtr-round-2","progress":1,'
+        b'"total":2,"message":"working","_meta":{"future":"value"}}}\n\n'
+        b"event: message\n"
+        b'data: {"jsonrpc":"2.0","id":31,"result":{"content":null,'
+        b'"resultType":"input_required","requestState":"next.opaque.state",'
+        b'"inputRequests":{"business_clarifications":{"type":"object",'
+        b'"futureKeyword":{"nested":[1,true,null]}}},'
+        b'"futureResultField":{"must":"survive"}}}\n\n'
+    )
+    seen_bodies: list[bytes] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen_bodies.append(await request.aread())
+        assert request.headers["mcp-protocol-version"] == "2026-07-28"
+        assert request.headers["mcp-method"] == "tools/call"
+        assert request.headers["mcp-name"] == "maxcompute_generate_sql"
+        assert request.headers["mcp-mrtr-round"] == "retry"
+        return httpx.Response(
+            200,
+            headers={
+                "content-type": "text/event-stream",
+                "mcp-future-response": "preserve-me-too",
+                "x-request-id": "gateway-mrtr-31",
+            },
+            stream=StaticAsyncStream(response_body[:97], response_body[97:]),
+        )
+
+    with (
+        patch(
+            "maxcompute_catalog_mcp.remote_http_proxy.httpx.AsyncClient",
+            side_effect=_patched_client_factory(handler),
+        ),
+        TestClient(_app(), base_url=LOCAL_BASE_URL) as client,
+    ):
+        response = client.post(
+            "/mcp",
+            headers={
+                "Accept": "application/json, text/event-stream",
+                "Content-Type": "application/json",
+                "Mcp-Method": "tools/call",
+                "Mcp-Name": "maxcompute_generate_sql",
+                "Mcp-Protocol-Version": "2026-07-28",
+                "Mcp-MRTR-Round": "retry",
+            },
+            content=request_body,
+        )
+
+    assert seen_bodies == [request_body]
+    assert response.content == response_body
+    assert response.headers["mcp-future-response"] == "preserve-me-too"
+
+
+@pytest.mark.parametrize(
+    "request_body",
+    [b"not-json", b"[]", b'{"jsonrpc":"2.0","id":true}'],
+)
+def test_transport_failure_without_request_id_returns_safe_generic_error(
+    request_body: bytes,
+) -> None:
+    """Uncorrelated network failures never invent or leak diagnostic details."""
+
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        raise RuntimeError("secret upstream diagnostic")
+
+    with (
+        patch(
+            "maxcompute_catalog_mcp.remote_http_proxy.httpx.AsyncClient",
+            side_effect=_patched_client_factory(handler),
+        ),
+        TestClient(_app(), base_url=LOCAL_BASE_URL) as client,
+    ):
+        response = client.post(
+            "/mcp",
+            headers={"Content-Type": "application/json"},
+            content=request_body,
+        )
+
+    assert response.status_code == 502
+    assert response.json() == {
+        "jsonrpc": "2.0",
+        "id": None,
+        "error": {
+            "code": -32000,
+            "message": "remote MCP request failed",
+        },
+    }
+    assert "secret upstream diagnostic" not in response.text
+
+
+def test_explicit_non_loopback_listener_validates_its_configured_host() -> None:
+    """An explicitly exposed listener still pins Host and Origin validation."""
+    upstream_calls = 0
+
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        nonlocal upstream_calls
+        upstream_calls += 1
+        return httpx.Response(202, stream=StaticAsyncStream())
+
+    app = build_remote_http_proxy_app(
+        RemoteRuntimeConfig(url=REMOTE_URL),
+        RotatingTokenProvider(),
+        host="0.0.0.0",
+        port=8123,
+    )
+    with (
+        patch(
+            "maxcompute_catalog_mcp.remote_http_proxy.httpx.AsyncClient",
+            side_effect=_patched_client_factory(handler),
+        ),
+        TestClient(app, base_url="http://0.0.0.0:8123") as client,
+    ):
+        response = client.post(
+            "/mcp",
+            headers={
+                "Content-Type": "application/json",
+                "Origin": "http://0.0.0.0:8123",
+            },
+            json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+        )
+
+    assert response.status_code == 202
+    assert upstream_calls == 1
+
+
+def test_remote_http_runner_serves_exact_app_and_listener() -> None:
+    """The process runner exposes the proxy app on the requested host and port."""
+    config = RemoteRuntimeConfig(url=REMOTE_URL)
+    provider = RotatingTokenProvider()
+    with (
+        patch(
+            "maxcompute_catalog_mcp.remote_http_proxy.build_remote_http_proxy_app",
+        ) as build_app_mock,
+        patch("uvicorn.run") as uvicorn_run_mock,
+    ):
+        run_remote_http_proxy(
+            config,
+            provider,
+            host="127.0.0.1",
+            port=8123,
+        )
+
+    build_app_mock.assert_called_once_with(
+        config,
+        provider,
+        host="127.0.0.1",
+        port=8123,
+    )
+    uvicorn_run_mock.assert_called_once_with(
+        build_app_mock.return_value,
+        host="127.0.0.1",
+        port=8123,
+    )

--- a/tests/test_remote_proxy.py
+++ b/tests/test_remote_proxy.py
@@ -8,7 +8,7 @@ import logging
 import sys
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import anyio
 import httpx2 as httpx
@@ -630,6 +630,104 @@ def test_bridge_preserves_non_requests_and_unversioned_notifications() -> None:
     assert response.metadata is None
     assert notification.metadata is None
     assert invalid_version.metadata is None
+
+
+def test_stdio_bridge_preserves_modern_mrtr_fields_without_interpreting_them() -> None:
+    """The stdio relay treats current and future MRTR payload fields as opaque."""
+    bridge = ProtocolMetadataBridge()
+    params = {
+        "name": "maxcompute_generate_sql",
+        "arguments": {"question": "revenue?"},
+        "requestState": "opaque.sealed.state",
+        "inputResponses": {
+            "business_clarifications": {
+                "action": "accept",
+                "content": {"time_semantics": "calendar month"},
+            }
+        },
+        "_meta": {
+            PROTOCOL_VERSION_META_KEY: MODERN_PROTOCOL_VERSION,
+            "io.modelcontextprotocol/clientCapabilities": {"elicitation": {"form": {}}},
+        },
+        "futureRequestField": {"must": "survive"},
+    }
+    request = mcp_types.JSONRPCRequest(
+        jsonrpc="2.0",
+        id=31,
+        method="tools/call",
+        params=params,
+    )
+    outbound = SessionMessage(request)
+
+    assert bridge.prepare_outbound(outbound) is outbound
+    assert outbound.message.params == params
+
+    result = {
+        "content": None,
+        "resultType": "input_required",
+        "requestState": "next.opaque.state",
+        "inputRequests": {
+            "business_clarifications": {
+                "type": "object",
+                "futureKeyword": {"nested": [1, True, None]},
+            }
+        },
+        "futureResultField": {"must": "survive"},
+    }
+    inbound = SessionMessage(
+        mcp_types.JSONRPCResponse(jsonrpc="2.0", id=31, result=result)
+    )
+
+    assert bridge.observe_inbound(inbound) is inbound
+    assert inbound.message.result == result
+
+
+def test_stdio_relay_forwards_mrtr_progress_and_input_required_in_order() -> None:
+    """The stdio relay does not filter MRTR progress or final result messages."""
+
+    async def scenario() -> None:
+        progress_params = {
+            "progressToken": "mrtr-round-2",
+            "progress": 1,
+            "total": 2,
+            "message": "working",
+            "_meta": {"futureProgressField": {"must": "survive"}},
+        }
+        progress = SessionMessage(
+            mcp_types.JSONRPCNotification(
+                jsonrpc="2.0",
+                method="notifications/progress",
+                params=progress_params,
+            )
+        )
+        result = {
+            "content": None,
+            "resultType": "input_required",
+            "requestState": "next.opaque.state",
+            "inputRequests": {
+                "business_clarifications": {
+                    "type": "object",
+                    "futureKeyword": {"nested": [1, True, None]},
+                }
+            },
+            "futureResultField": {"must": "survive"},
+        }
+        input_required = SessionMessage(
+            mcp_types.JSONRPCResponse(jsonrpc="2.0", id=31, result=result)
+        )
+
+        async def source():
+            yield progress
+            yield input_required
+
+        target = MagicMock(send=AsyncMock())
+        await relay_server_messages(source(), target, ProtocolMetadataBridge())
+
+        assert target.send.await_args_list == [call(progress), call(input_required)]
+        assert progress.message.params == progress_params
+        assert input_required.message.result == result
+
+    asyncio.run(scenario())
 
 
 def test_modern_bridge_preserves_existing_headers_and_omits_invalid_name() -> None:

--- a/tests/test_runtime_config.py
+++ b/tests/test_runtime_config.py
@@ -425,8 +425,8 @@ def test_explicit_local_mode_preserves_legacy_runtime(tmp_path: Path) -> None:
     assert config.remote is None
 
 
-def test_non_stdio_default_selection_preserves_local_server(tmp_path: Path) -> None:
-    """Existing HTTP self-hosting cannot be replaced by the stdio-only relay."""
+def test_default_remote_selection_is_transport_agnostic(tmp_path: Path) -> None:
+    """Default mode keeps its Remote candidate for Streamable HTTP."""
     path = _write_config(
         tmp_path,
         _legacy_config(
@@ -437,18 +437,22 @@ def test_non_stdio_default_selection_preserves_local_server(tmp_path: Path) -> N
     config = load_runtime_config(path, allow_remote=False)
 
     assert config.mode is RuntimeMode.DEFAULT
-    assert config.remote is None
+    assert config.remote is not None
+    assert config.remote.url == ("https://mcp.cn-hangzhou.maxcompute.aliyun.com/mcp")
 
 
-def test_explicit_remote_non_stdio_is_rejected(tmp_path: Path) -> None:
+def test_explicit_remote_is_transport_agnostic(tmp_path: Path) -> None:
     document = _legacy_config(
         "https://service.cn-hangzhou.maxcompute.aliyun.com/api",
     )
     document["mode"] = "remote"
     path = _write_config(tmp_path, document)
 
-    with pytest.raises(ValueError, match="only available with stdio"):
-        load_runtime_config(path, allow_remote=False)
+    config = load_runtime_config(path, allow_remote=False)
+
+    assert config.mode is RuntimeMode.REMOTE
+    assert config.remote is not None
+    assert config.remote.url == ("https://mcp.cn-hangzhou.maxcompute.aliyun.com/mcp")
 
 
 def test_named_profile_drives_network_and_region_selection(tmp_path: Path) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -26,9 +26,12 @@ from maxcompute_catalog_mcp.server import (
     _initialize_remote_mcp,
     _parse_args,
     _parse_server_options,
+    _run_default_http,
     _run_default_stdio,
+    _run_forced_remote_http,
     _run_forced_remote_stdio,
     _run_http,
+    _run_remote_http,
     _run_stdio,
     build_remote_token_provider,
     build_tools,
@@ -192,6 +195,69 @@ def test_main_remote_mode_builds_token_provider_but_not_local_tools(
     probe_remote_mock.assert_awaited_once()
     run_remote_mock.assert_awaited_once()
     assert run_remote_mock.await_args.args[1] is token_provider
+
+
+def test_main_remote_streamable_http_builds_no_local_tools(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Remote HTTP startup probes auth and then serves the transparent proxy."""
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "mode": "remote",
+                "remote": {"url": "http://127.0.0.1:8080/mcp"},
+                "maxcompute": {
+                    "maxcompute_endpoint": (
+                        "https://service.cn-hangzhou.maxcompute.aliyun.com/api"
+                    ),
+                    "catalogapi_endpoint": "https://catalog.example.com",
+                    "accessKeyId": "fixture-ak",
+                    "accessKeySecret": "fixture-sk",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "alibabacloud-maxcompute-mcp-server",
+            "--config",
+            str(config_path),
+            "--transport",
+            "streamable-http",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "8123",
+        ],
+    )
+    token_provider = MagicMock()
+
+    with (
+        patch("maxcompute_catalog_mcp.server.build_tools") as build_tools_mock,
+        patch(
+            "maxcompute_catalog_mcp.server.build_remote_token_provider",
+            return_value=token_provider,
+        ),
+        patch(
+            "maxcompute_catalog_mcp.server._run_forced_remote_http",
+        ) as run_remote_http_mock,
+    ):
+        main()
+
+    build_tools_mock.assert_not_called()
+    run_remote_http_mock.assert_called_once()
+    selected, selected_provider = run_remote_http_mock.call_args.args[:2]
+    assert selected.url == "http://127.0.0.1:8080/mcp"
+    assert selected_provider is token_provider
+    assert run_remote_http_mock.call_args.kwargs == {
+        "host": "127.0.0.1",
+        "port": 8123,
+    }
 
 
 class TestDefaultMode:
@@ -401,6 +467,161 @@ class TestDefaultMode:
             asyncio.run(_run_default_stdio(self._runtime(), None))
 
         build_tools_mock.assert_not_called()
+
+
+class TestDefaultHttpMode:
+    @staticmethod
+    def _runtime() -> RuntimeConfig:
+        return RuntimeConfig(
+            mode=RuntimeMode.DEFAULT,
+            profile="daily",
+            remote=RemoteRuntimeConfig(
+                url="https://mcp.cn-hangzhou.maxcompute.aliyun.com/mcp",
+            ),
+        )
+
+    def test_successful_initialize_selects_remote_http_proxy(self) -> None:
+        runtime = self._runtime()
+        provider = MagicMock()
+        provider.get_access_token = AsyncMock(return_value="catalog-token")
+        with (
+            patch(
+                "maxcompute_catalog_mcp.server.build_remote_token_provider",
+                return_value=provider,
+            ),
+            patch(
+                "maxcompute_catalog_mcp.server._probe_remote_mcp",
+                new_callable=AsyncMock,
+            ) as probe_mock,
+            patch(
+                "maxcompute_catalog_mcp.server._run_remote_http",
+            ) as remote_http_mock,
+            patch("maxcompute_catalog_mcp.server.build_tools") as build_tools_mock,
+        ):
+            _run_default_http(
+                runtime,
+                "/fake/config.json",
+                host="127.0.0.1",
+                port=8123,
+            )
+
+        probe_mock.assert_awaited_once_with(runtime.remote, provider)
+        remote_http_mock.assert_called_once_with(
+            runtime.remote,
+            provider,
+            host="127.0.0.1",
+            port=8123,
+        )
+        build_tools_mock.assert_not_called()
+
+    def test_initialize_failure_falls_back_to_local_http(self) -> None:
+        runtime = self._runtime()
+        provider = MagicMock()
+        provider.get_access_token = AsyncMock(return_value="catalog-token")
+        local_tools = MagicMock()
+        with (
+            patch(
+                "maxcompute_catalog_mcp.server.build_remote_token_provider",
+                return_value=provider,
+            ),
+            patch(
+                "maxcompute_catalog_mcp.server._probe_remote_mcp",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("gateway unavailable"),
+            ),
+            patch("maxcompute_catalog_mcp.server._run_remote_http") as remote_http_mock,
+            patch(
+                "maxcompute_catalog_mcp.server.build_tools",
+                return_value=local_tools,
+            ),
+            patch("maxcompute_catalog_mcp.server._run_http") as local_http_mock,
+        ):
+            _run_default_http(
+                runtime,
+                None,
+                host="127.0.0.1",
+                port=8123,
+            )
+
+        remote_http_mock.assert_not_called()
+        local_http_mock.assert_called_once_with(
+            local_tools,
+            host="127.0.0.1",
+            port=8123,
+        )
+
+    def test_remote_runtime_failure_after_selection_does_not_fall_back(self) -> None:
+        runtime = self._runtime()
+        provider = MagicMock()
+        provider.get_access_token = AsyncMock(return_value="catalog-token")
+        with (
+            patch(
+                "maxcompute_catalog_mcp.server.build_remote_token_provider",
+                return_value=provider,
+            ),
+            patch(
+                "maxcompute_catalog_mcp.server._probe_remote_mcp",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "maxcompute_catalog_mcp.server._run_remote_http",
+                side_effect=RuntimeError("remote stream lost"),
+            ),
+            patch("maxcompute_catalog_mcp.server.build_tools") as build_tools_mock,
+            pytest.raises(RuntimeError, match="remote stream lost"),
+        ):
+            _run_default_http(
+                runtime,
+                None,
+                host="127.0.0.1",
+                port=8123,
+            )
+
+        build_tools_mock.assert_not_called()
+
+
+def test_forced_remote_http_initialize_failure_is_fail_closed() -> None:
+    config = RemoteRuntimeConfig(url="https://gateway.example.com/mcp")
+    provider = MagicMock()
+    provider.get_access_token = AsyncMock(return_value="catalog-token")
+    with (
+        patch(
+            "maxcompute_catalog_mcp.server._probe_remote_mcp",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("unauthorized"),
+        ),
+        patch("maxcompute_catalog_mcp.server._run_remote_http") as remote_http_mock,
+        pytest.raises(RemoteInitializationError, match="initialization failed"),
+    ):
+        _run_forced_remote_http(
+            config,
+            provider,
+            host="127.0.0.1",
+            port=8123,
+        )
+
+    remote_http_mock.assert_not_called()
+
+
+def test_run_remote_http_delegates_to_transport_implementation() -> None:
+    config = RemoteRuntimeConfig(url="https://gateway.example.com/mcp")
+    provider = MagicMock()
+    with patch(
+        "maxcompute_catalog_mcp.remote_http_proxy.run_remote_http_proxy"
+    ) as run_mock:
+        _run_remote_http(
+            config,
+            provider,
+            host="127.0.0.1",
+            port=8123,
+        )
+
+    run_mock.assert_called_once_with(
+        config,
+        provider,
+        host="127.0.0.1",
+        port=8123,
+    )
 
 
 def test_forced_remote_initialize_failure_is_fail_closed() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -235,6 +235,7 @@ dependencies = [
     { name = "mcp" },
     { name = "pyodps-catalog" },
     { name = "requests" },
+    { name = "starlette" },
     { name = "urllib3" },
     { name = "uvicorn" },
 ]
@@ -290,6 +291,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.1.0" },
     { name = "requests", specifier = ">=2.33.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.16.1" },
+    { name = "starlette", specifier = ">=1.6.0,<2" },
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "uvicorn", specifier = ">=0.52.4" },
 ]


### PR DESCRIPTION
## Summary

- support `remote` and remote-first `default` mode over both stdio and Streamable HTTP
- proxy Streamable HTTP JSON/SSE, sessions, resumption and MCP extension headers without rebuilding remote tool messages
- preserve MRTR/progress/future MCP fields and add available request IDs to failure bodies
- keep explicit `remote` fail-closed and fall back to the optional local SDK only during `default` startup selection

## Verification

- `738 passed, 223 skipped`
- line coverage `95.59%` (required `80%`)
- branch coverage `91.21%` (required `90%`)
- Ruff, format, mypy, lockfile check and strict dependency audit passed
- clean-wheel E2E passed for AK/SK, OAuth-derived STS and credentials URI through CatalogAPI token issuance and Remote MCP
- standard OAuth MCP access was separately verified through an existing authenticated MCP OAuth client
- `default`, `remote` and `local` were exercised over stdio and Streamable HTTP, including real read-only `list_projects` calls, local fallback and fail-closed failures
- wheel/sdist metadata and install smoke checks passed; the base install remains free of PyODPS/PyArrow while the `local` extra installs both
