### PR TITLE
release: v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.1.6] - 2026-08-26
+
 ### Added
 
 - `default` and `remote` modes now expose a transparent Streamable HTTP proxy
@@ -60,7 +62,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Rule-based public and VPC endpoint derivation for Mainland China and
   international Regions without a fixed Region registry.
 
-[Unreleased]: https://github.com/aliyun/alibabacloud-maxcompute-mcp-server/compare/v0.1.5...HEAD
+[Unreleased]: https://github.com/aliyun/alibabacloud-maxcompute-mcp-server/compare/v0.1.6...HEAD
+[0.1.6]: https://github.com/aliyun/alibabacloud-maxcompute-mcp-server/compare/v0.1.5...v0.1.6
 [0.1.5]: https://github.com/aliyun/alibabacloud-maxcompute-mcp-server/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/aliyun/alibabacloud-maxcompute-mcp-server/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/aliyun/alibabacloud-maxcompute-mcp-server/compare/v0.1.2...v0.1.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "alibabacloud-maxcompute-mcp-server"
-version = "0.1.5"
+version = "0.1.6"
 description = "MCP (Model Context Protocol) server for Alibaba Cloud MaxCompute — list projects/schemas/tables, search metadata, execute SQL, and manage instances via Catalog API and PyODPS."
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -220,7 +220,7 @@ wheels = [
 
 [[package]]
 name = "alibabacloud-maxcompute-mcp-server"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- release the Remote Streamable HTTP proxy as `v0.1.6`
- move the accepted Streamable HTTP proxy changes from `Unreleased` into the `0.1.6` changelog section
- update project and lockfile versions to `0.1.6`

## Verification

- merged feature SHA `79ca659` passed all master CI workflows
- `uv lock --check` and release metadata consistency checks passed
- `738 passed, 223 skipped` after syncing all extras and dependency groups
- wheel and sdist build passed
- `twine check --strict` and `check-wheel-contents` passed
- isolated wheel version/import and CLI smoke tests passed
