### PR TITLE
fix: remote stdio relay read timeout and opt-in for unverifiable remote URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ token renewal, or Gateway transport failures terminate the remote flow.
 has selected remote, a later remote-session failure never invokes local SDK
 tools dynamically.
 
+A remote hostname outside the known endpoint registry is rejected, because its
+network type cannot be proven from the hostname alone. Set
+`MAXCOMPUTE_ALLOW_UNVERIFIED_REMOTE_URL=1` to proceed explicitly for such a
+target; the launcher prints a warning and the default fail-closed behavior
+stays unchanged.
+
 ### Requirements
 
 The launcher needs:

--- a/maxcompute_catalog_mcp/remote_proxy.py
+++ b/maxcompute_catalog_mcp/remote_proxy.py
@@ -24,6 +24,7 @@ from .request_ids import sanitize_request_id
 from .runtime_config import RemoteRuntimeConfig
 
 _REMOTE_INITIALIZATION_TIMEOUT_SECONDS = 10.0
+_REMOTE_CONNECT_TIMEOUT_SECONDS = 30.0
 _REQUEST_ID_HEADER = "X-Request-ID"
 _REQUEST_ID_META_KEY = "com.aliyun.maxcompute/requestId"
 _LOGGER = logging.getLogger(__name__)
@@ -270,6 +271,7 @@ async def probe_remote_mcp(
                     auth=DynamicBearerAuth(token_provider),
                     event_hooks={"response": [request_ids.observe_response]},
                     follow_redirects=False,
+                    timeout=httpx.Timeout(_REMOTE_INITIALIZATION_TIMEOUT_SECONDS),
                     trust_env=False,
                 ) as mcp_client,
                 streamable_http_client(
@@ -368,6 +370,10 @@ async def _run_remote_proxy_with_provider(
             auth=DynamicBearerAuth(token_provider),
             event_hooks={"response": [request_ids.observe_response]},
             follow_redirects=False,
+            # Long-running MCP tool calls (SQL synchronous waits, KB/LLM
+            # answers) exceed any small default; only the connect phase is
+            # bounded here, matching the Streamable HTTP reverse proxy.
+            timeout=httpx.Timeout(_REMOTE_CONNECT_TIMEOUT_SECONDS, read=None),
             trust_env=False,
         ) as mcp_client,
         stdio_server() as (

--- a/maxcompute_catalog_mcp/runtime_config.py
+++ b/maxcompute_catalog_mcp/runtime_config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import sys
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
@@ -238,6 +239,15 @@ def _validate_network_compatibility(
         return
     remote = _mcp_endpoint_identity(remote_url)
     if remote is None:
+        if os.getenv("MAXCOMPUTE_ALLOW_UNVERIFIED_REMOTE_URL"):
+            # The remote host does not match the known endpoint registry,
+            # so its network type cannot be proven from the hostname alone.
+            # Stay fail-closed by default; proceed only on explicit opt-in.
+            sys.stderr.write(
+                "warning: remote MCP URL network type cannot be verified; "
+                "proceeding because MAXCOMPUTE_ALLOW_UNVERIFIED_REMOTE_URL is set\n"
+            )
+            return
         raise ValueError("remote MCP URL network type cannot be verified")
     if remote.network is not maxcompute.network:
         raise ValueError(

--- a/tests/test_remote_proxy.py
+++ b/tests/test_remote_proxy.py
@@ -126,6 +126,10 @@ def test_remote_proxy_uses_exact_hardened_http_client_and_relay_wiring() -> None
         assert kwargs["auth"]._provider is provider
         assert kwargs["follow_redirects"] is False
         assert kwargs["trust_env"] is False
+        timeout = kwargs["timeout"]
+        assert isinstance(timeout, httpx.Timeout)
+        assert timeout.connect == 30.0
+        assert timeout.read is None
         response_hooks = kwargs["event_hooks"]["response"]
         assert len(response_hooks) == 1
         assert isinstance(response_hooks[0].__self__, RemoteRequestIdTracker)

--- a/tests/test_runtime_config.py
+++ b/tests/test_runtime_config.py
@@ -609,6 +609,43 @@ def test_explicit_remote_rejects_unsafe_targets(
         load_runtime_config(path)
 
 
+def test_unrecognized_remote_url_stays_fail_closed(tmp_path: Path) -> None:
+    document = _legacy_config(
+        "https://service.cn-hangzhou.maxcompute.aliyun.com/api",
+    )
+    document.update(
+        {
+            "mode": "remote",
+            "remote": {"url": "https://mcp-slot.internal.example.net/mcp"},
+        }
+    )
+    path = _write_config(tmp_path, document)
+
+    with pytest.raises(ValueError, match="cannot be verified"):
+        load_runtime_config(path)
+
+
+def test_unrecognized_remote_url_opt_in_proceeds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MAXCOMPUTE_ALLOW_UNVERIFIED_REMOTE_URL", "1")
+    url = "https://mcp-slot.internal.example.net/mcp"
+    document = _legacy_config(
+        "https://service.cn-hangzhou.maxcompute.aliyun.com/api",
+    )
+    document.update({"mode": "remote", "remote": {"url": url}})
+    path = _write_config(tmp_path, document)
+
+    config = load_runtime_config(path)
+
+    assert config.mode is RuntimeMode.REMOTE
+    assert config.remote is not None
+    assert config.remote.url == url
+    assert "network type cannot be verified" in capsys.readouterr().err
+
+
 def test_explicit_loopback_remote_is_available_for_local_integration(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

Two follow-ups from a full-environment acceptance run of the remote MCP path (28 endpoints, 2026-08-27).

### 1. `fix: keep remote stdio relay open for long-running MCP calls`

`_run_remote_proxy_with_provider` (and `probe_remote_mcp`) created `httpx.AsyncClient` without a `timeout`, so httpx's **5-second default applied to every phase**. Any gateway tool call slower than 5s — `sql_execute` synchronous waits run up to 2 minutes, `kb_ask`/`generate_sql` regularly exceed it — was cut off by a client-side `ReadTimeout`, and the relay session died mid-call, leaving the MCP client hanging on an unanswered request (then `Connection closed` on the next call).

Evidence captured with `httpcore2` debug logging against a production endpoint:

```
13:57:28.636 httpcore2.http11 DEBUG receive_response_headers.started request=<Request [b'POST']>
13:57:33.637 httpcore2.http11 DEBUG receive_response_headers.failed exception=ReadTimeout(TimeoutError())
```

Gateway SLS audit for the same call recorded `result=success` with ~5-8s duration — the server had answered; the client gave up. This also explains the intermittent appearance: it is simply whether the backend latency crosses the 5s line.

Fix: bound only the connect phase (30s) and leave reads open (`httpx.Timeout(30.0, read=None)`), matching the Streamable HTTP reverse proxy client in `remote_http_proxy.py`. Probe keeps a 10s all-phase cap aligned with the existing initialization timeout.

Verified: after the fix, the previously failing endpoint returns `sql_execute` in ~6s through the full stdio path; `tests/test_remote_proxy.py` extended with timeout regression assertions.

### 2. `feat: allow explicit opt-in for unverifiable remote MCP URLs`

Remote hostnames outside the known endpoint registry stay fail-closed by default. This adds `MAXCOMPUTE_ALLOW_UNVERIFIED_REMOTE_URL=1` for operators who need to point the launcher at a non-registry target; a warning is printed and defaults are unchanged. README updated.

## Testing

- `tests/test_remote_proxy.py` (33), `tests/test_remote_http_proxy.py` + `tests/test_runtime_config.py` (73 incl. 2 new opt-in tests) all pass.
- Live regression after the fix: global, Beijing, Chengdu, Shanghai, Shenzhen, Wulanchabu `sql_execute` + `quota` + `skill` + `kb_ask` all pass (SQL 2.7-10.4s); Zhangjiakou `kb_ask` passes.