### PR TITLE
fix: fail fast when the remote relay silently drops the first request

### DIFF
--- a/maxcompute_catalog_mcp/remote_proxy.py
+++ b/maxcompute_catalog_mcp/remote_proxy.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 from collections.abc import AsyncGenerator, AsyncIterable
 from dataclasses import replace
 from typing import Any, Protocol
@@ -25,6 +26,9 @@ from .runtime_config import RemoteRuntimeConfig
 
 _REMOTE_INITIALIZATION_TIMEOUT_SECONDS = 10.0
 _REMOTE_CONNECT_TIMEOUT_SECONDS = 30.0
+_RELAY_FIRST_RESPONSE_TIMEOUT_SECONDS = 30.0
+_RELAY_WATCHDOG_POLL_SECONDS = 1.0
+_REMOTE_REQUEST_ERROR_CODE = -32000
 _REQUEST_ID_HEADER = "X-Request-ID"
 _REQUEST_ID_META_KEY = "com.aliyun.maxcompute/requestId"
 _LOGGER = logging.getLogger(__name__)
@@ -45,6 +49,10 @@ class RemoteMCPInitializationFailure(RuntimeError):
         if self.request_id is not None:
             message = f"{message} (request_id={self.request_id})"
         super().__init__(message)
+
+
+class RelayFirstExchangeStalled(RuntimeError):
+    """The first forwarded request never received any remote response."""
 
 
 class RemoteRequestIdTracker:
@@ -129,6 +137,24 @@ class ProtocolMetadataBridge:
         self._initialize_request_id: int | str | None = None
         self._legacy_protocol_version: str | None = None
         self._request_ids = request_ids
+        self._pending_requests: dict[int | str, float] = {}
+        self.first_response_observed = False
+
+    def stalled_request_id(self, timeout: float) -> int | str | None:
+        """Return the oldest unanswered request ID once it exceeds the timeout.
+
+        Only the first exchange is watched: once any remote response has been
+        observed the session is proven live and later long-running tool calls
+        are not bounded here.
+        """
+
+        if self.first_response_observed:
+            return None
+        now = time.monotonic()
+        for request_id, forwarded_at in self._pending_requests.items():
+            if now - forwarded_at >= timeout:
+                return request_id
+        return None
 
     def prepare_outbound(self, message: SessionMessage) -> SessionMessage:
         """Attach transport metadata while preserving the JSON-RPC object."""
@@ -139,6 +165,9 @@ class ProtocolMetadataBridge:
             mcp_types.JSONRPCRequest | mcp_types.JSONRPCNotification,
         ):
             return message
+
+        if isinstance(payload, mcp_types.JSONRPCRequest):
+            self._pending_requests.setdefault(payload.id, time.monotonic())
 
         if (
             isinstance(payload, mcp_types.JSONRPCRequest)
@@ -169,6 +198,11 @@ class ProtocolMetadataBridge:
         """Remember protocol state and add HTTP correlation to failures."""
 
         payload = message.message
+        if isinstance(payload, mcp_types.JSONRPCResponse | mcp_types.JSONRPCError):
+            self.first_response_observed = True
+            if payload.id is not None:
+                self._pending_requests.pop(payload.id, None)
+
         if (
             isinstance(payload, mcp_types.JSONRPCResponse)
             and payload.id == self._initialize_request_id
@@ -318,6 +352,44 @@ async def relay_server_messages(
         await target.send(bridge.observe_inbound(message))
 
 
+async def _watch_first_exchange(
+    local_write: Any,
+    bridge: ProtocolMetadataBridge,
+) -> None:
+    """Fail fast when the first forwarded request is silently dropped.
+
+    Some transport races cancel the initial POST inside the Streamable HTTP
+    client without ever notifying the stdio peer, leaving the MCP client
+    hanging on an unanswered initialize. When no response arrives within the
+    budget, surface a JSON-RPC error to the peer and abort the relay instead
+    of stalling silently.
+    """
+
+    while not bridge.first_response_observed:
+        await anyio.sleep(_RELAY_WATCHDOG_POLL_SECONDS)
+        stalled_id = bridge.stalled_request_id(_RELAY_FIRST_RESPONSE_TIMEOUT_SECONDS)
+        if stalled_id is None:
+            continue
+        _LOGGER.error(
+            "Remote MCP relay stall: request id=%r received no response within %.0fs",
+            stalled_id,
+            _RELAY_FIRST_RESPONSE_TIMEOUT_SECONDS,
+        )
+        error = mcp_types.JSONRPCError(
+            jsonrpc="2.0",
+            id=stalled_id,
+            error=mcp_types.ErrorData(
+                code=_REMOTE_REQUEST_ERROR_CODE,
+                message="remote relay delivered no response for this request",
+            ),
+        )
+        await local_write.send(SessionMessage(error))
+        raise RelayFirstExchangeStalled(
+            f"request id={stalled_id!r} received no remote response within "
+            f"{_RELAY_FIRST_RESPONSE_TIMEOUT_SECONDS:.0f}s"
+        )
+
+
 async def relay_bidirectional(
     local_read: Any,
     local_write: Any,
@@ -346,6 +418,7 @@ async def relay_bidirectional(
             remote_read,
             local_write,
         )
+        tasks.start_soon(_watch_first_exchange, local_write, bridge)
 
 
 async def run_remote_proxy(

--- a/tests/test_remote_proxy.py
+++ b/tests/test_remote_proxy.py
@@ -19,9 +19,11 @@ from mcp.shared.message import ClientMessageMetadata, SessionMessage
 from maxcompute_catalog_mcp.remote_proxy import (
     DynamicBearerAuth,
     ProtocolMetadataBridge,
+    RelayFirstExchangeStalled,
     RemoteMCPInitializationFailure,
     RemoteRequestIdTracker,
     _run_remote_proxy_with_provider,
+    _watch_first_exchange,
     probe_remote_mcp,
     relay_client_messages,
     relay_server_messages,
@@ -954,5 +956,91 @@ def test_streamable_http_400_jsonrpc_error_returns_without_timeout() -> None:
             assert received.message.error.data == {
                 "request_id": "gateway-invalid-request-1"
             }
+
+    asyncio.run(scenario())
+
+
+def test_bridge_stall_detection_only_watches_first_exchange() -> None:
+    """Pending tracking arms on requests and disarms after any response."""
+
+    bridge = ProtocolMetadataBridge()
+    assert bridge.stalled_request_id(0.0) is None
+
+    initialize = mcp_types.JSONRPCRequest(
+        jsonrpc="2.0",
+        id=1,
+        method="initialize",
+        params={"protocolVersion": "2025-06-18"},
+    )
+    bridge.prepare_outbound(SessionMessage(initialize))
+    assert bridge.stalled_request_id(0.0) == 1
+
+    response = mcp_types.JSONRPCResponse(
+        jsonrpc="2.0",
+        id=1,
+        result={"protocolVersion": "2025-06-18"},
+    )
+    bridge.observe_inbound(SessionMessage(response))
+    assert bridge.first_response_observed is True
+
+    later = mcp_types.JSONRPCRequest(
+        jsonrpc="2.0",
+        id=2,
+        method="tools/call",
+        params={"name": "example"},
+    )
+    bridge.prepare_outbound(SessionMessage(later))
+    assert bridge.stalled_request_id(0.0) is None
+
+
+def test_watch_first_exchange_fails_fast_on_silent_stall() -> None:
+    """A dropped initial request surfaces a JSON-RPC error and aborts."""
+
+    async def scenario() -> None:
+        bridge = ProtocolMetadataBridge()
+        initialize = mcp_types.JSONRPCRequest(
+            jsonrpc="2.0",
+            id=1,
+            method="initialize",
+            params={"protocolVersion": "2025-06-18"},
+        )
+        bridge.prepare_outbound(SessionMessage(initialize))
+        bridge._pending_requests[1] -= 60.0
+
+        local_write = AsyncMock()
+        with (
+            patch(
+                "maxcompute_catalog_mcp.remote_proxy."
+                "_RELAY_FIRST_RESPONSE_TIMEOUT_SECONDS",
+                30.0,
+            ),
+            patch(
+                "maxcompute_catalog_mcp.remote_proxy._RELAY_WATCHDOG_POLL_SECONDS",
+                0,
+            ),
+            pytest.raises(RelayFirstExchangeStalled, match="id=1"),
+        ):
+            await _watch_first_exchange(local_write, bridge)
+
+        local_write.send.assert_awaited_once()
+        sent = local_write.send.call_args.args[0]
+        assert isinstance(sent.message, mcp_types.JSONRPCError)
+        assert sent.message.id == 1
+        assert sent.message.error.code == -32000
+
+    asyncio.run(scenario())
+
+
+def test_watch_first_exchange_returns_once_session_is_live() -> None:
+    """After the first response the watchdog exits without error."""
+
+    async def scenario() -> None:
+        bridge = ProtocolMetadataBridge()
+        bridge.first_response_observed = True
+        local_write = AsyncMock()
+
+        await _watch_first_exchange(local_write, bridge)
+
+        local_write.send.assert_not_awaited()
 
     asyncio.run(scenario())


### PR DESCRIPTION
Fixes #29.

## Problem

Issue #29 captured a soak-test reproduction: after a normal startup
probe, the relay forwarded the client's `initialize`, but the transport
cancelled the POST locally within ~1ms and then stayed completely silent
— no error, no log, no exit — until the client's own 30s timeout killed
the process. The MCP client has no way today to distinguish "slow
gateway" from "the relay swallowed a transport failure".

## Fix

`ProtocolMetadataBridge` now tracks forwarded requests and whether any
remote response has been observed. A watchdog task in
`relay_bidirectional` watches only the first exchange:

- If the first forwarded request receives no response within 30s, the
  relay sends a JSON-RPC error (`-32000`) for the stalled request to the
  stdio peer, logs the stall, and aborts with a non-zero exit
  (`RelayFirstExchangeStalled`).
- Once any response has been observed the session is proven live and the
  watchdog disarms; later long-running tool calls (SQL waits, KB/LLM
  answers) are never bounded by it.

## Verification

- New unit tests: bridge stall-tracking arming/disarming, watchdog
  fail-fast path, watchdog disarm after first response (107 tests pass
  across the remote modules).
- Live soak after the fix: 60/60 kb rounds against a production
  endpoint passed; earlier soak rounds (40 + 100 + 7) saw no other
  regressions. The race itself is rare (~1%), but when it fires the
  relay now fails fast and visibly instead of hanging.