### PR TITLE
release: v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.1.7] - 2026-08-27
+
+### Added
+
+- `MAXCOMPUTE_ALLOW_UNVERIFIED_REMOTE_URL=1` opt-in lets explicit `remote`
+  mode proceed for a remote MCP hostname outside the known endpoint
+  registry; the default stays fail-closed and a warning is printed when
+  the opt-in is used.
+- The stdio relay now runs a watchdog over the first exchange: if the
+  first forwarded request receives no remote response within 30 seconds,
+  the relay sends a JSON-RPC error for the stalled request, logs the
+  stall, and exits non-zero instead of hanging silently.
+
+### Fixed
+
+- The remote stdio relay built its HTTP client without an explicit
+  timeout, so the httpx five-second default applied to every request
+  phase and cut off any gateway call slower than five seconds (SQL
+  synchronous waits, KB/LLM answers). Only the connect phase is bounded
+  now (30 seconds); reads stay open, matching the Streamable HTTP
+  reverse proxy client.
+
+### Changed
+
+- Dependencies: `mcp` 2.0.0 -> 2.1.1, `cryptography` -> 50.0.1, `anthropic`
+  (dev) 0.122.0 -> 1.1.0; `astral-sh/setup-uv` v9.0.0 -> v10.0.1 and
+  `zizmorcore/zizmor-action` v0.6.1 -> v0.6.2.
+
 ## [0.1.6] - 2026-08-26
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "alibabacloud-maxcompute-mcp-server"
-version = "0.1.6"
+version = "0.1.7"
 description = "MCP (Model Context Protocol) server for Alibaba Cloud MaxCompute — list projects/schemas/tables, search metadata, execute SQL, and manage instances via Catalog API and PyODPS."
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -220,7 +220,7 @@ wheels = [
 
 [[package]]
 name = "alibabacloud-maxcompute-mcp-server"
-version = "0.1.6"
+version = "0.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Release v0.1.7: version bump, lock sync, and changelog for the three
fixes merged today:

- #28 remote stdio relay read timeout fix + unverifiable-URL opt-in
- #30 first-exchange watchdog (fail fast instead of silent stall, fixes #29)
- #31 consolidated dependency updates (mcp 2.1.1, cryptography 50.0.1,
  anthropic 1.1.0, setup-uv v10.0.1, zizmor-action v0.6.2)

All changes already verified on master: 743 tests + mypy + ruff clean,
and a post-merge live rerun passed 21/23 production endpoints (the two
Hong Kong entries remain blocked by the pending rollout/egress change).