### PR TITLE
fix: derive VPC CatalogAPI endpoints on the VPC network plane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- VPC endpoint derivation no longer emits an internal-only hostname that a
+  customer VPC cannot route to. A `service.<region>-vpc...` FE endpoint now
+  derives `catalogapi.<region>-vpc...`, and `network: "vpc"` synthesizes the
+  matching `-vpc` FE and CatalogAPI endpoints. Previously both paths produced
+  a hostname on a different network plane, so remote startup failed with
+  `Remote MCP token issuance failed during initialization` after a
+  five-second connect timeout.
+- An FE endpoint that is neither public nor VPC no longer derives a CatalogAPI
+  endpoint. Remote startup now fails closed with an explicit error unless
+  `catalogapi_endpoint` (or `MAXCOMPUTE_CATALOG_API_ENDPOINT`) is configured.
+
 ## [0.1.7] - 2026-08-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   endpoint. Remote startup now fails closed with an explicit error unless
   `catalogapi_endpoint` (or `MAXCOMPUTE_CATALOG_API_ENDPOINT`) is configured.
 
+### Changed
+
+- Endpoint recognition no longer treats the internal-plane hostname suffix as a
+  VPC endpoint; only the `-vpc` suffix is recognized. Internal-plane endpoints
+  now contribute no Region/network evidence, so they neither synthesize a VPC
+  MCP endpoint nor mask a conflicting configuration: `default` mode stays on
+  the local implementation and explicit `remote` mode fails closed with a clear
+  error. A configuration that mixes an unrecognized FE endpoint with a
+  recognized CatalogAPI endpoint now derives the remote endpoint from the
+  recognized evidence, because remote mode never uses the FE endpoint.
+
 ## [0.1.7] - 2026-08-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ The simplest endpoint configuration is:
 ```
 
 `region` and `network` synthesize FE, Catalog, and MCP endpoints by rule.
-`network: "vpc"` uses intranet FE/Catalog endpoints and a VPC MCP endpoint.
+`network: "vpc"` uses VPC FE/Catalog endpoints and a VPC MCP endpoint.
 
 #### Local-mode credential precedence
 
@@ -293,17 +293,22 @@ no Region list:
 
 | Service | public rule | VPC rule |
 | --- | --- | --- |
-| FE | `https://service.<region>.maxcompute.aliyun.com/api` | `https://service.<region>-intranet.maxcompute.aliyun-inc.com/api` |
-| CatalogAPI | `https://catalogapi.<region>.maxcompute.aliyun.com` | `https://catalogapi.<region>-intranet.maxcompute.aliyun-inc.com` |
+| FE | `https://service.<region>.maxcompute.aliyun.com/api` | `https://service.<region>-vpc.maxcompute.aliyun-inc.com/api` |
+| CatalogAPI | `https://catalogapi.<region>.maxcompute.aliyun.com` | `https://catalogapi.<region>-vpc.maxcompute.aliyun-inc.com` |
 | MCP for Mainland China Region (`cn-*`, except `cn-hongkong`) | `https://mcp.<region>.maxcompute.aliyun.com/mcp` | `https://mcp.<region>-vpc.maxcompute.aliyun-inc.com/mcp` |
 | MCP for overseas Region (including `cn-hongkong`) | `https://mcp-intl.<region>.maxcompute.aliyun.com/mcp` | `https://mcp-intl.<region>-vpc.maxcompute.aliyun-inc.com/mcp` |
 
 For legacy configuration, recognized FE and Catalog endpoints both contribute
-Region/network evidence. Public endpoints select public MCP; recognized VPC or
-intranet endpoints select VPC MCP. When both endpoints are recognized, they
+Region/network evidence. Public endpoints select public MCP; recognized VPC
+endpoints select VPC MCP. When both endpoints are recognized, they
 must identify the same Region and network. Conflicting endpoints never select
 remote, and explicit `region`/`network` values that contradict a recognized
 endpoint are rejected as invalid configuration.
+
+CatalogAPI is derived only from a public or VPC FE endpoint. Any other FE shape
+leaves CatalogAPI unset, so remote startup fails closed with an explicit error
+unless `catalogapi_endpoint` (or `MAXCOMPUTE_CATALOG_API_ENDPOINT`) is
+configured.
 
 A VPC configuration never selects public MCP or crosses Regions. Custom or
 historical endpoints with no verifiable Region/network or conflicting

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -267,15 +267,19 @@ Streamable HTTP 模式下，所有客户端共享同一个当前配置，一个�
 
 | 服务 | public 规则 | VPC 规则 |
 | --- | --- | --- |
-| FE | `https://service.<region>.maxcompute.aliyun.com/api` | `https://service.<region>-intranet.maxcompute.aliyun-inc.com/api` |
-| CatalogAPI | `https://catalogapi.<region>.maxcompute.aliyun.com` | `https://catalogapi.<region>-intranet.maxcompute.aliyun-inc.com` |
+| FE | `https://service.<region>.maxcompute.aliyun.com/api` | `https://service.<region>-vpc.maxcompute.aliyun-inc.com/api` |
+| CatalogAPI | `https://catalogapi.<region>.maxcompute.aliyun.com` | `https://catalogapi.<region>-vpc.maxcompute.aliyun-inc.com` |
 | 中国内地 Region MCP（`cn-*`，不含 `cn-hongkong`） | `https://mcp.<region>.maxcompute.aliyun.com/mcp` | `https://mcp.<region>-vpc.maxcompute.aliyun-inc.com/mcp` |
 | 海外 Region MCP（含 `cn-hongkong`） | `https://mcp-intl.<region>.maxcompute.aliyun.com/mcp` | `https://mcp-intl.<region>-vpc.maxcompute.aliyun-inc.com/mcp` |
 
 对于老配置，能够识别的 FE 和 Catalog endpoint 都会提供 Region/网络证据：公网
-endpoint 选择公网 MCP，已识别的 VPC/内网 endpoint 选择 VPC MCP。两者都能识别时，
+endpoint 选择公网 MCP，已识别的 VPC endpoint 选择 VPC MCP。两者都能识别时，
 必须指向相同 Region 和网络；二者冲突时绝不选择 remote。显式 `region`/`network`
 与已识别 endpoint 冲突则视为配置错误。
+
+CatalogAPI 只从公网或 VPC 形态的 FE endpoint 推导。其它形态的 FE 不会推导出
+CatalogAPI，remote 启动会 fail closed 并给出明确报错，除非显式配置
+`catalogapi_endpoint`（或 `MAXCOMPUTE_CATALOG_API_ENDPOINT`）。
 
 VPC 配置绝不选择公网 MCP，也不跨 Region。只有自定义/历史 endpoint 且无法验证
 Region/网络或 FE/Catalog 证据冲突时，`default` 保持原 local 实现；显式 `remote`

--- a/maxcompute_catalog_mcp/config.py
+++ b/maxcompute_catalog_mcp/config.py
@@ -49,7 +49,7 @@ _PUBLIC_MAXCOMPUTE_HOST = re.compile(
 )
 _VPC_MAXCOMPUTE_HOST = re.compile(
     r"^service\.(?P<region>[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?)"
-    r"(?:-intranet|-vpc)\.maxcompute\.aliyun-inc\.com$"
+    r"(?P<suffix>-intranet|-vpc)\.maxcompute\.aliyun-inc\.com$"
 )
 
 
@@ -110,10 +110,10 @@ def _resolve_simple_endpoints(
             )
         else:
             maxcompute_endpoint = maxcompute_endpoint or (
-                f"https://service.{region}-intranet.maxcompute.aliyun-inc.com/api"
+                f"https://service.{region}-vpc.maxcompute.aliyun-inc.com/api"
             )
             catalogapi_endpoint = catalogapi_endpoint or (
-                f"https://catalogapi.{region}-intranet.maxcompute.aliyun-inc.com"
+                f"https://catalogapi.{region}-vpc.maxcompute.aliyun-inc.com"
             )
     if not catalogapi_endpoint and maxcompute_endpoint:
         catalogapi_endpoint = _catalogapi_endpoint_for_standard_fe(maxcompute_endpoint)
@@ -121,7 +121,12 @@ def _resolve_simple_endpoints(
 
 
 def _catalogapi_endpoint_for_standard_fe(maxcompute_endpoint: str) -> str:
-    """Derive the CatalogAPI endpoint for a recognized standard FE endpoint."""
+    """Derive the CatalogAPI endpoint for a recognized standard FE endpoint.
+
+    Returns an empty string when the FE endpoint is not a public or VPC
+    customer endpoint, so the caller requires an explicit
+    ``catalogapi_endpoint`` instead of guessing a network plane.
+    """
 
     value = (maxcompute_endpoint or "").strip()
     parsed = urlsplit(value if "://" in value else f"//{value}")
@@ -131,9 +136,13 @@ def _catalogapi_endpoint_for_standard_fe(maxcompute_endpoint: str) -> str:
         region = public_match.group("region")
         return f"https://catalogapi.{region}.maxcompute.aliyun.com"
     vpc_match = _VPC_MAXCOMPUTE_HOST.fullmatch(host)
-    if vpc_match is not None:
+    # Only the -vpc suffix is a customer VPC endpoint. The -intranet suffix is
+    # a separate internal network plane that a customer VPC cannot route to, so
+    # deriving it here would send CatalogAPI calls to an unreachable host and
+    # surface only as an opaque token-issuance failure.
+    if vpc_match is not None and vpc_match.group("suffix") == "-vpc":
         region = vpc_match.group("region")
-        return f"https://catalogapi.{region}-intranet.maxcompute.aliyun-inc.com"
+        return f"https://catalogapi.{region}-vpc.maxcompute.aliyun-inc.com"
     return ""
 
 

--- a/maxcompute_catalog_mcp/config.py
+++ b/maxcompute_catalog_mcp/config.py
@@ -49,7 +49,7 @@ _PUBLIC_MAXCOMPUTE_HOST = re.compile(
 )
 _VPC_MAXCOMPUTE_HOST = re.compile(
     r"^service\.(?P<region>[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?)"
-    r"(?P<suffix>-intranet|-vpc)\.maxcompute\.aliyun-inc\.com$"
+    r"-vpc\.maxcompute\.aliyun-inc\.com$"
 )
 
 
@@ -136,11 +136,7 @@ def _catalogapi_endpoint_for_standard_fe(maxcompute_endpoint: str) -> str:
         region = public_match.group("region")
         return f"https://catalogapi.{region}.maxcompute.aliyun.com"
     vpc_match = _VPC_MAXCOMPUTE_HOST.fullmatch(host)
-    # Only the -vpc suffix is a customer VPC endpoint. The -intranet suffix is
-    # a separate internal network plane that a customer VPC cannot route to, so
-    # deriving it here would send CatalogAPI calls to an unreachable host and
-    # surface only as an opaque token-issuance failure.
-    if vpc_match is not None and vpc_match.group("suffix") == "-vpc":
+    if vpc_match is not None:
         region = vpc_match.group("region")
         return f"https://catalogapi.{region}-vpc.maxcompute.aliyun-inc.com"
     return ""

--- a/maxcompute_catalog_mcp/runtime_config.py
+++ b/maxcompute_catalog_mcp/runtime_config.py
@@ -60,16 +60,14 @@ _PUBLIC_MAXCOMPUTE_HOST = re.compile(
 )
 _VPC_MAXCOMPUTE_HOST = re.compile(
     rf"^service\.(?P<region>{_REGION_PATTERN})"
-    r"(?:-intranet|-vpc)"
-    r"\.maxcompute\.aliyun-inc\.com$"
+    r"-vpc\.maxcompute\.aliyun-inc\.com$"
 )
 _PUBLIC_CATALOGAPI_HOST = re.compile(
     rf"^catalogapi\.(?P<region>{_REGION_PATTERN})\.maxcompute\.aliyun\.com$"
 )
 _VPC_CATALOGAPI_HOST = re.compile(
     rf"^catalogapi\.(?P<region>{_REGION_PATTERN})"
-    r"(?:-intranet|-vpc)"
-    r"\.maxcompute\.aliyun-inc\.com$"
+    r"-vpc\.maxcompute\.aliyun-inc\.com$"
 )
 _PUBLIC_MCP_HOST = re.compile(
     rf"^mcp(?:-intl)?\.(?P<region>{_REGION_PATTERN})\.maxcompute\.aliyun\.com$"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -60,8 +60,14 @@ def test_config_repr_redacts_credentials() -> None:
             "https://catalogapi.cn-hangzhou.maxcompute.aliyun.com",
         ),
         (
+            "https://service.ap-southeast-1-vpc.maxcompute.aliyun-inc.com/api",
+            "https://catalogapi.ap-southeast-1-vpc.maxcompute.aliyun-inc.com",
+        ),
+        # The -intranet plane is internal and unreachable from a customer VPC,
+        # so it is never derived; an explicit catalogapi_endpoint is required.
+        (
             "https://service.ap-southeast-1-intranet.maxcompute.aliyun-inc.com/api",
-            "https://catalogapi.ap-southeast-1-intranet.maxcompute.aliyun-inc.com",
+            "",
         ),
     ],
 )
@@ -379,8 +385,8 @@ def test_load_config_missing_endpoint_raises(tmp_path: Path) -> None:
         (
             "eu-central-1",
             "vpc",
-            "https://service.eu-central-1-intranet.maxcompute.aliyun-inc.com/api",
-            "https://catalogapi.eu-central-1-intranet.maxcompute.aliyun-inc.com",
+            "https://service.eu-central-1-vpc.maxcompute.aliyun-inc.com/api",
+            "https://catalogapi.eu-central-1-vpc.maxcompute.aliyun-inc.com",
         ),
     ],
 )
@@ -452,10 +458,10 @@ def test_simple_region_network_environment_config_synthesizes_vpc_endpoints(
 
     assert cfg.network == "vpc"
     assert cfg.maxcompute_endpoint == (
-        "https://service.ap-southeast-1-intranet.maxcompute.aliyun-inc.com/api"
+        "https://service.ap-southeast-1-vpc.maxcompute.aliyun-inc.com/api"
     )
     assert cfg.catalogapi_endpoint == (
-        "https://catalogapi.ap-southeast-1-intranet.maxcompute.aliyun-inc.com"
+        "https://catalogapi.ap-southeast-1-vpc.maxcompute.aliyun-inc.com"
     )
 
 
@@ -666,10 +672,10 @@ class TestLoadConfigs:
         assert default_name == "hz-vpc"
         assert configs["hz-vpc"].network == "vpc"
         assert configs["hz-vpc"].maxcompute_endpoint == (
-            "https://service.cn-hangzhou-intranet.maxcompute.aliyun-inc.com/api"
+            "https://service.cn-hangzhou-vpc.maxcompute.aliyun-inc.com/api"
         )
         assert configs["hz-vpc"].catalogapi_endpoint == (
-            "https://catalogapi.cn-hangzhou-intranet.maxcompute.aliyun-inc.com"
+            "https://catalogapi.cn-hangzhou-vpc.maxcompute.aliyun-inc.com"
         )
 
     def test_multi_named_configs(self, tmp_path: Path) -> None:

--- a/tests/test_runtime_config.py
+++ b/tests/test_runtime_config.py
@@ -83,9 +83,10 @@ def test_legacy_vpc_config_uses_only_same_region_vpc_mcp(
     )
 
 
-def test_legacy_intranet_fe_and_catalog_endpoints_select_vpc_mcp(
+def test_legacy_intranet_endpoints_contribute_no_network_evidence(
     tmp_path: Path,
 ) -> None:
+    """Internal-plane endpoints are outside the public endpoint registry."""
     path = _write_config(
         tmp_path,
         _legacy_config(
@@ -99,10 +100,7 @@ def test_legacy_intranet_fe_and_catalog_endpoints_select_vpc_mcp(
     config = load_runtime_config(path)
 
     assert config.mode is RuntimeMode.DEFAULT
-    assert config.remote is not None
-    assert config.remote.url == (
-        "https://mcp.cn-hangzhou-vpc.maxcompute.aliyun-inc.com/mcp"
-    )
+    assert config.remote is None
 
 
 def test_legacy_catalog_endpoint_can_supply_network_when_fe_is_custom(
@@ -135,7 +133,7 @@ def test_legacy_vpc_catalog_endpoint_can_supply_network_when_fe_is_custom(
         _legacy_config(
             "https://custom-fe.example.com/api",
             catalogapi_endpoint=(
-                "https://catalogapi.cn-hongkong-intranet.maxcompute.aliyun-inc.com"
+                "https://catalogapi.cn-hongkong-vpc.maxcompute.aliyun-inc.com"
             ),
         ),
     )
@@ -155,9 +153,9 @@ def test_conflicting_legacy_fe_and_catalog_networks_do_not_guess(
     path = _write_config(
         tmp_path,
         _legacy_config(
-            "https://service.cn-hangzhou.maxcompute.aliyun.com/api",
+            "https://service.cn-hangzhou-vpc.maxcompute.aliyun-inc.com/api",
             catalogapi_endpoint=(
-                "https://catalogapi.cn-hangzhou-intranet.maxcompute.aliyun-inc.com"
+                "https://catalogapi.cn-hangzhou.maxcompute.aliyun.com"
             ),
         ),
     )


### PR DESCRIPTION
## What

Fix VPC endpoint derivation so a customer VPC configuration reaches CatalogAPI
on the VPC network plane.

- `_catalogapi_endpoint_for_standard_fe()` derives
  `catalogapi.<region>-vpc...` from a `service.<region>-vpc...` FE endpoint. An
  FE endpoint that is neither public nor VPC now derives nothing, so remote
  startup fails closed instead of guessing a network plane.
- `_resolve_simple_endpoints()` synthesizes the `-vpc` FE and CatalogAPI
  endpoints for `network: "vpc"`.
- README and README_ZH: the endpoint tables now document the VPC plane for FE
  and CatalogAPI, the `network: "vpc"` sentence no longer describes internal
  endpoints, and a note records that CatalogAPI is derived only from public or
  VPC FE endpoints.
- CHANGELOG entry under `Unreleased`.
- Tests: the derivation parametrize now covers a `-vpc` FE endpoint and asserts
  that an internal-plane FE endpoint derives nothing; the three synthesis tests
  assert `-vpc`.

Recognition of explicitly configured endpoints (`_VPC_MAXCOMPUTE_HOST` and
`_VPC_CATALOGAPI_HOST` in `runtime_config.py`) is deliberately **unchanged**, so
a configuration that sets both endpoints directly keeps behaving exactly as
before. Only derivation and synthesis change.

## Why

Fixes #34.

Before this change a VPC FE endpoint derived a CatalogAPI hostname on the
internal network plane, which a customer VPC cannot route to.
`POST /api/catalog/v1alpha/mcpAccessToken` never connected, burned the five
second connect timeout, and surfaced only as
`Remote MCP token issuance failed during initialization`. Because
`_regional_mcp_url()` already used `-vpc`, one configuration spanned two network
planes, and `EndpointNetwork` classified both suffixes as `vpc` so the
consistency check could not catch it.

## Verification

Repository gates, run with `uv` on Python 3.10 using the same commands as CI:

- `uv run pytest tests/ -q --cov=maxcompute_catalog_mcp --cov-fail-under=80`
  → 744 passed, 223 skipped, total coverage 94.44%
- `uv run python scripts/check_coverage.py coverage.json --line-fail-under 80
  --branch-fail-under 90` → line 95.62%, branch 91.17%
- `uv run ruff check maxcompute_catalog_mcp tests scripts` → all checks passed
- `uv run ruff format --check ...` → 59 files already formatted
- `uv run mypy maxcompute_catalog_mcp` → no issues in 21 source files

End to end from an ECS instance inside a customer VPC, running the launcher
itself (`python -m maxcompute_catalog_mcp --mode remote --transport stdio`) with
real short-lived STS credentials and driving it with JSON-RPC over stdio:

| Case | Configuration | Derived CatalogAPI | Result |
| --- | --- | --- | --- |
| Reported shape, before fix | VPC FE only | internal plane | exit 1 after ~5 s, `Remote MCP token issuance failed during initialization` |
| Reported shape, after fix | VPC FE only | `-vpc` | `initialize` OK, `tools/list` returns 44 tools |
| Simple config, after fix | `region` + `network: "vpc"` | `-vpc` | `initialize` OK, 44 tools |
| Public FE, guard | public FE | public | `initialize` OK, 44 tools |
| Explicit internal pair, guard | both endpoints set explicitly | unchanged | validation still passes; fails only on network reachability, exactly as before |
| Internal FE, no CatalogAPI, new | internal FE only | not derived | fails closed with `Remote MCP token provider initialization failed` |

The repository test suite was also re-run inside the VPC against the patched
tree: 744 passed, 223 skipped.

## Not addressed here

- The underlying `CatalogTokenRequestError` is still discarded by two
  `raise ... from None` sites. The new fail-closed path therefore reports
  `Remote MCP token provider initialization failed` without the actionable
  "set `catalogapi_endpoint`" detail that `build_catalog_client_set()` raises.
  Worth a follow-up on error propagation.
- `tests/test_remote_auth.py` needs `alibabacloud_tea_openapi`, which is not a
  declared dependency.


## Second commit: endpoint recognition no longer folds the internal plane into VPC

`EndpointNetwork` is binary and the MCP host registry only knows the `-vpc`
private form, so any recognized non-public FE or CatalogAPI hostname folded
into the VPC plane and `_regional_mcp_url()` synthesized a `-vpc` MCP endpoint
for it. For an internal-plane configuration that derived endpoint is
unreachable on the plane the configuration implies, so the classification only
produced a misrouting; it did not protect anything.

The recognition regexes now match only the `-vpc` suffix in both
`runtime_config.py` and `config.py`. Consequences, all covered by updated or
new tests:

- Internal-plane endpoints contribute no Region/network evidence. `default`
  mode stays on the local implementation; explicit `remote` mode fails closed
  with `remote MCP endpoint cannot be derived from the MaxCompute config`
  instead of burning the CatalogAPI connect timeout.
- A configuration mixing an unrecognized FE endpoint with a recognized
  CatalogAPI endpoint now derives the remote endpoint from the recognized
  evidence, because remote mode never uses the FE endpoint. Previously such a
  pair was treated as conflicting and produced no remote candidate.
- `test_legacy_intranet_fe_and_catalog_endpoints_select_vpc_mcp` became
  `test_legacy_intranet_endpoints_contribute_no_network_evidence`;
  `test_legacy_vpc_catalog_endpoint_can_supply_network_when_fe_is_custom` now
  uses a `-vpc` CatalogAPI endpoint; the conflicting-pair test now uses a
  genuinely conflicting `-vpc` FE plus public CatalogAPI pair.

Verification of the updated tree from inside the customer VPC, same five cases
as above:

| Case | Configuration | Result |
| --- | --- | --- |
| Reported shape | VPC FE only | `initialize` OK, `tools/list` 44 tools |
| Simple config | `region` + `network: "vpc"` | `initialize` OK, 44 tools |
| Public FE | public FE | `initialize` OK, 44 tools |
| Explicit internal pair | both endpoints internal | fails closed at config validation with the derivation error |
| Internal FE, no CatalogAPI | internal FE only | fails closed at config validation with the derivation error |

Repository gates re-run on the updated tree: 744 passed, 223 skipped; line
95.62%, branch 91.17%; ruff and mypy clean.
