### PR TITLE
fix: pass the view and query arguments pyodps-catalog 0.4.0 requires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - An FE endpoint that is neither public nor VPC no longer derives a CatalogAPI
   endpoint. Remote startup now fails closed with an explicit error unless
   `catalogapi_endpoint` (or `MAXCOMPUTE_CATALOG_API_ENDPOINT`) is configured.
+- Local-mode `list_tables` and `get_partition_info` now pass the `view` and
+  `query` arguments that pyodps-catalog 0.4.0 requires. Omitting them raised a
+  `TypeError` at call time, which surfaced as a tool error in local mode while
+  every mocked unit test stayed green, because the shared fake client accepts
+  any keyword arguments. A new signature-contract test binds the arguments the
+  launcher passes to the installed SDK signature so this drift fails in CI.
 
 ### Changed
 

--- a/maxcompute_catalog_mcp/tools_catalog.py
+++ b/maxcompute_catalog_mcp/tools_catalog.py
@@ -107,11 +107,15 @@ class CatalogMixin:
         token = opt_arg(args, "token")
         table_filter = opt_arg(args, "filter")
 
+        # pyodps-catalog 0.4.0 declares view and query as required arguments
+        # and leaves them out of the request only when they are unset.
         list_kwargs: dict[str, Any] = {
             "project_id": project,
             "schema_name": schema,
             "page_size": page_size,
             "page_token": token,
+            "view": None,
+            "query": None,
         }
         resp = self.sdk.client.list_tables(**list_kwargs)
         m = resp.to_map() if hasattr(resp, "to_map") else resp
@@ -222,6 +226,8 @@ class CatalogMixin:
                 table_name=table,
                 page_size=page_size,
                 page_token=token,
+                query=None,
+                view=None,
             )
         except AttributeError:
             return _unsupported("Current Catalog SDK does not support list_partitions.")

--- a/tests/test_catalog_sdk_contract.py
+++ b/tests/test_catalog_sdk_contract.py
@@ -1,0 +1,51 @@
+"""Signature-contract tests against the installed Catalog SDK.
+
+pyodps-catalog 0.4.0 turned ``view`` and ``query`` into required arguments of
+``Client.list_tables`` and ``Client.list_partitions``. The shared unit-test
+fake client is a ``MagicMock``, which accepts any keyword arguments, so a
+launcher that omits a required argument passes every mocked test and only
+fails at runtime in local mode. These tests bind the arguments the launcher
+actually passed to the signature of the installed SDK client, so signature
+drift fails in CI instead of in a customer's local session.
+"""
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import MagicMock
+
+from pyodps_catalog.client import Client as CatalogClient
+
+from maxcompute_catalog_mcp.tools import Tools
+from tests.conftest import data as _data
+from tests.conftest import text_payload as _text_payload
+
+
+def _assert_call_matches_sdk_signature(client: MagicMock, method_name: str) -> None:
+    call = getattr(client, method_name).call_args
+    assert call is not None, f"{method_name} was never called"
+    signature = inspect.signature(getattr(CatalogClient, method_name))
+    # bind() raises TypeError when the launcher omitted a required argument.
+    signature.bind(None, *call.args, **call.kwargs)
+
+
+def test_list_tables_passes_every_required_sdk_argument(tools: Tools) -> None:
+    r = tools.call("list_tables", {"project": "p1", "schema": "default"})
+    payload = _text_payload(r)
+    assert "error" not in payload, payload.get("error")
+
+    _assert_call_matches_sdk_signature(tools.sdk.client, "list_tables")
+
+
+def test_get_partition_info_passes_every_required_sdk_argument(
+    tools: Tools,
+) -> None:
+    r = tools.call(
+        "get_partition_info",
+        {"project": "p1", "schema": "default", "table": "t1"},
+    )
+    payload = _text_payload(r)
+    assert "error" not in payload, payload.get("error")
+    assert "partitions" in _data(payload)
+
+    _assert_call_matches_sdk_signature(tools.sdk.client, "list_partitions")


### PR DESCRIPTION
## What

Pass the `view` and `query` arguments that pyodps-catalog 0.4.0 requires to
`Client.list_tables` and `Client.list_partitions`, and add a signature-contract
test so this class of drift fails in CI.

- `tools_catalog.py`: both call sites now pass `view=None, query=None`. The SDK
  omits unset values from the request, so the wire behavior matches what the
  launcher sent before the SDK made the arguments required. A non-`BASIC` view
  would additionally flip the request to an internal API scope, so unset is the
  correct value here.
- `tests/test_catalog_sdk_contract.py`: binds the arguments the launcher
  actually passed (recorded from the fake client) to the signature of the
  installed `pyodps_catalog.client.Client`, so omitting a required argument
  fails the suite instead of failing later in a local session.
- CHANGELOG entry under `Unreleased`.

## Why

Fixes #36.

pyodps-catalog 0.4.0 turned `view` and `query` into required positional-or-
keyword arguments of `list_tables` and `list_partitions`. The launcher omitted
them, so local mode raised
`TypeError: Client.list_tables() missing 2 required positional arguments: 'view' and 'query'`
before any HTTP request was made. The unit suite could not catch it because the
shared fake client is a `MagicMock` (it accepts any keyword arguments) and the
real-API tests are credential-gated and skipped in CI.

## Verification

Repository gates with `uv` on Python 3.10, same commands as CI:

- `uv run pytest tests/ -q --cov=maxcompute_catalog_mcp --cov-fail-under=80`
  → 745 passed, 223 skipped, total coverage 94.44%
- `uv run python scripts/check_coverage.py coverage.json --line-fail-under 80
  --branch-fail-under 90` → line 95.62%, branch 91.17%
- `uv run ruff check maxcompute_catalog_mcp tests scripts` → all checks passed
- `uv run ruff format --check ...` → 60 files already formatted
- `uv run mypy maxcompute_catalog_mcp` → no issues in 21 source files

Red/green for the new contract tests: with the source fix stashed, both fail
with the binding `TypeError`; with the fix they pass.

End to end in local mode against a public CatalogAPI endpoint, driving the real
server over stdio with JSON-RPC:

| Code | `list_tables` on a nonexistent project | Interpretation |
| --- | --- | --- |
| Before fix | `Client.list_tables() missing 2 required positional arguments: 'view' and 'query'` | died locally, no HTTP request |
| After fix | server-side project-not-found error with a request ID | the request reached the CatalogAPI tables endpoint |

## Not addressed here

- The mocked fake client still accepts arbitrary keyword arguments; the new
  contract test compensates for that rather than replacing the fake.
