### PR TITLE
release: v0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.1.8] - 2026-09-04
+
 ### Fixed
 
 - VPC endpoint derivation no longer emits an internal-only hostname that a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "alibabacloud-maxcompute-mcp-server"
-version = "0.1.7"
+version = "0.1.8"
 description = "MCP (Model Context Protocol) server for Alibaba Cloud MaxCompute — list projects/schemas/tables, search metadata, execute SQL, and manage instances via Catalog API and PyODPS."
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -220,7 +220,7 @@ wheels = [
 
 [[package]]
 name = "alibabacloud-maxcompute-mcp-server"
-version = "0.1.7"
+version = "0.1.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Release preparation for 0.1.8.

- `pyproject.toml` version 0.1.7 -> 0.1.8, `uv.lock` updated.
- CHANGELOG: the Unreleased entries are archived under `## [0.1.8] - 2026-09-04`.

Contents: the VPC endpoint derivation and recognition fixes (#35), the
local-mode pyodps-catalog 0.4.0 required-argument fix with its
signature-contract test (#37), and the dev-dependency bump (#33).

Per `docs/publishing.md`, the release is verified by repository CI on the exact
merge commit and built/published by `publish.yml` from the tag. The local
wheel checks (`uv build`, `twine check --strict`, `check-wheel-contents`) were
not run on the preparing workstation because its egress to PyPI was down at
preparation time; the publish workflow performs the build from the tag.

After this merges and CI is green on the merge commit, tag `v0.1.8` at that
commit to trigger publication.
